### PR TITLE
Update gitignore ipynb_checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 
 # ipython/jupyter notebooks
 *.ipynb
+**/.ipynb_checkpoints/
 
 # Editor temporaries
 *.swn


### PR DESCRIPTION
JupyterLab (not sure about Jupyter Notebook) automatically create checkpoints folder when run any .ipynb notebook.
It makes sense to ignore them.