### PR TITLE
Make pretrained model dir customizable

### DIFF
--- a/maskrcnn_benchmark/config/defaults.py
+++ b/maskrcnn_benchmark/config/defaults.py
@@ -267,3 +267,4 @@ _C.TEST.IMS_PER_BATCH = 8
 _C.OUTPUT_DIR = "."
 
 _C.PATHS_CATALOG = os.path.join(os.path.dirname(__file__), "paths_catalog.py")
+_C.PRETRAINED_DIR = ""

--- a/maskrcnn_benchmark/utils/checkpoint.py
+++ b/maskrcnn_benchmark/utils/checkpoint.py
@@ -125,7 +125,7 @@ class DetectronCheckpointer(Checkpointer):
         # download url files
         if f.startswith("http"):
             # if the file is a url path, download it and cache it
-            cached_f = cache_url(f)
+            cached_f = cache_url(f, self.cfg.PRETRAINED_DIR)
             self.logger.info("url {} cached in {}".format(f, cached_f))
             f = cached_f
         # convert Caffe2 checkpoint from pkl

--- a/maskrcnn_benchmark/utils/model_zoo.py
+++ b/maskrcnn_benchmark/utils/model_zoo.py
@@ -29,7 +29,7 @@ def cache_url(url, model_dir=None, progress=True):
     Example:
         >>> cached_file = maskrcnn_benchmark.utils.model_zoo.cache_url('https://s3.amazonaws.com/pytorch/models/resnet18-5c106cde.pth')
     """
-    if model_dir is None:
+    if model_dir is None or model_dir == "":
         torch_home = os.path.expanduser(os.getenv('TORCH_HOME', '~/.torch'))
         model_dir = os.getenv('TORCH_MODEL_ZOO', os.path.join(torch_home, 'models'))
     if not os.path.exists(model_dir):


### PR DESCRIPTION
Training machines might not have an internet connection and it can be useful to customize the location of pretrained models. For example, training machines could share a network attached drive for these models. 

To this end, this change adds the setting `PRETRAINED_DIR`. 