### PR TITLE
Update balanced_positive_negative_sampler.py

### DIFF
--- a/maskrcnn_benchmark/modeling/balanced_positive_negative_sampler.py
+++ b/maskrcnn_benchmark/modeling/balanced_positive_negative_sampler.py
@@ -46,8 +46,8 @@ class BalancedPositiveNegativeSampler(object):
             num_neg = min(negative.numel(), num_neg)
 
             # randomly select positive and negative examples
-            perm1 = torch.randperm(positive.numel())[:num_pos]
-            perm2 = torch.randperm(negative.numel())[:num_neg]
+            perm1 = torch.randperm(positive.numel(), device=positive.device)[:num_pos]
+            perm2 = torch.randperm(negative.numel(), device=negative.device)[:num_neg]
 
             pos_idx_per_image = positive[perm1]
             neg_idx_per_image = negative[perm2]


### PR DESCRIPTION
Avoid unnecessary and unexpected copy from gpu to cpu.

I am trying to implement a multi-thread data parallel module instead of distributed modules. I have modified the data structure and almost finish it. I find a fatal bug when you use cpu version torch.randperm and multi-thread, it will raise Segmentation Fault during forward around a certain iteration.

I heard this repo is created for a benchmark performance contest, so I wonder whether you care about flexibility apart from speed. Distributed learning has to load the whole dataset multiple times. I guess it is why you do not use fixed proposals like Detectron, since proposal files need large memory, which your implementation is hard to support.