### PR TITLE
Pass OUTPUT_DIR to Checkpointer during inference

### DIFF
--- a/maskrcnn_benchmark/structures/bounding_box.py
+++ b/maskrcnn_benchmark/structures/bounding_box.py
@@ -224,12 +224,11 @@ class BoxList(object):
         return self
 
     def area(self):
-        if self.mode == 'xyxy':
+        box = self.bbox
+        if self.mode == "xyxy":
             TO_REMOVE = 1
-            box = self.bbox
             area = (box[:, 2] - box[:, 0] + TO_REMOVE) * (box[:, 3] - box[:, 1] + TO_REMOVE)
-        elif self.mode == 'xywh':
-            box = self.bbox
+        elif self.mode == "xywh":
             area = box[:, 2] * box[:, 3]
         else:
             raise RuntimeError("Should not be here")

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -60,7 +60,8 @@ def main():
     model = build_detection_model(cfg)
     model.to(cfg.MODEL.DEVICE)
 
-    checkpointer = DetectronCheckpointer(cfg, model)
+    output_dir = cfg.OUTPUT_DIR
+    checkpointer = DetectronCheckpointer(cfg, model, save_dir=output_dir)
     _ = checkpointer.load(cfg.MODEL.WEIGHT)
 
     iou_types = ("bbox",)


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/maskrcnn-benchmark/issues/92

Also fixes some linter issues (we use `"` instead of `'` for strings).