### PR TITLE
Fix repeatedly invoke build_detection_model error.

### DIFF
--- a/maskrcnn_benchmark/modeling/backbone/resnet.py
+++ b/maskrcnn_benchmark/modeling/backbone/resnet.py
@@ -34,22 +34,22 @@ StageSpec = namedtuple(
 # Standard ResNet models
 # -----------------------------------------------------------------------------
 # ResNet-50 (including all stages)
-ResNet50StagesTo5 = (
+ResNet50StagesTo5 = tuple(
     StageSpec(index=i, block_count=c, return_features=r)
     for (i, c, r) in ((1, 3, False), (2, 4, False), (3, 6, False), (4, 3, True))
 )
 # ResNet-50 up to stage 4 (excludes stage 5)
-ResNet50StagesTo4 = (
+ResNet50StagesTo4 = tuple(
     StageSpec(index=i, block_count=c, return_features=r)
     for (i, c, r) in ((1, 3, False), (2, 4, False), (3, 6, True))
 )
 # ResNet-50-FPN (including all stages)
-ResNet50FPNStagesTo5 = (
+ResNet50FPNStagesTo5 = tuple(
     StageSpec(index=i, block_count=c, return_features=r)
     for (i, c, r) in ((1, 3, True), (2, 4, True), (3, 6, True), (4, 3, True))
 )
 # ResNet-101-FPN (including all stages)
-ResNet101FPNStagesTo5 = (
+ResNet101FPNStagesTo5 = tuple(
     StageSpec(index=i, block_count=c, return_features=r)
     for (i, c, r) in ((1, 3, True), (2, 4, True), (3, 23, True), (4, 3, True))
 )


### PR DESCRIPTION
## Bug
When I repeatedly invoke build_detection_model function to build the model, I will get the error: `AttributeError: 'ResNet' object has no attribute 'layer1'`. 

## To Reproduce
```
model = build_detection_model(cfg)
model = build_detection_model(cfg)
```

## The reason
The variable `ResNet50StagesTo4` is a global generator expression, so when we build the model secondly, the code executes to Line 82 `for stage_spec in stage_specs:` and `stage_specs` will return empty leading to do not add any stage. Finally, `self._freeze_backbone` try to freeze the backbone by executing `m = getattr(self, "layer" + str(stage_index))` firstly. At the moment, it will throw the AttributeError `AttributeError: 'ResNet' object has no attribute 'layer1'`.

I guess you want to define ResNet50StagesTo4 as the tuple, so I try to fix by add tuple type qualifier.

## The solution
Add the tuple type to `ResNet50StagesTo5`, `ResNet50StagesTo4`, `ResNet50FPNStagesTo5`, `ResNet101FPNStagesTo5`.

I do not know whether there are similar bugs existing, so you need to review my solution. Thank you!