### PR TITLE
Add registry for model builder functions

### DIFF
--- a/maskrcnn_benchmark/config/defaults.py
+++ b/maskrcnn_benchmark/config/defaults.py
@@ -134,6 +134,8 @@ _C.MODEL.RPN.MIN_SIZE = 0
 # all FPN levels
 _C.MODEL.RPN.FPN_POST_NMS_TOP_N_TRAIN = 2000
 _C.MODEL.RPN.FPN_POST_NMS_TOP_N_TEST = 2000
+# Custom rpn head, empty to use default conv or separable conv
+_C.MODEL.RPN.RPN_HEAD = "SingleConvRPNHead"
 
 
 # ---------------------------------------------------------------------------- #

--- a/maskrcnn_benchmark/modeling/backbone/resnet.py
+++ b/maskrcnn_benchmark/modeling/backbone/resnet.py
@@ -18,6 +18,7 @@ from torch import nn
 
 from maskrcnn_benchmark.layers import FrozenBatchNorm2d
 from maskrcnn_benchmark.layers import Conv2d
+from maskrcnn_benchmark.utils.registry import Registry
 
 
 # ResNet stage specification
@@ -290,30 +291,15 @@ class StemWithFixedBatchNorm(nn.Module):
         return x
 
 
-_TRANSFORMATION_MODULES = {"BottleneckWithFixedBatchNorm": BottleneckWithFixedBatchNorm}
+_TRANSFORMATION_MODULES = Registry({
+    "BottleneckWithFixedBatchNorm": BottleneckWithFixedBatchNorm
+})
 
-_STEM_MODULES = {"StemWithFixedBatchNorm": StemWithFixedBatchNorm}
+_STEM_MODULES = Registry({"StemWithFixedBatchNorm": StemWithFixedBatchNorm})
 
-_STAGE_SPECS = {
+_STAGE_SPECS = Registry({
     "R-50-C4": ResNet50StagesTo4,
     "R-50-C5": ResNet50StagesTo5,
     "R-50-FPN": ResNet50FPNStagesTo5,
     "R-101-FPN": ResNet101FPNStagesTo5,
-}
-
-
-def register_transformation_module(module_name, module):
-    _register_generic(_TRANSFORMATION_MODULES, module_name, module)
-
-
-def register_stem_module(module_name, module):
-    _register_generic(_STEM_MODULES, module_name, module)
-
-
-def register_stage_spec(stage_spec_name, stage_spec):
-    _register_generic(_STAGE_SPECS, stage_spec_name, stage_spec)
-
-
-def _register_generic(module_dict, module_name, module):
-    assert module_name not in module_dict
-    module_dict[module_name] = module
+})

--- a/maskrcnn_benchmark/modeling/registry.py
+++ b/maskrcnn_benchmark/modeling/registry.py
@@ -1,0 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+from maskrcnn_benchmark.utils.registry import Registry
+
+BACKBONES = Registry()
+ROI_BOX_FEATURE_EXTRACTORS = Registry()

--- a/maskrcnn_benchmark/modeling/registry.py
+++ b/maskrcnn_benchmark/modeling/registry.py
@@ -4,3 +4,4 @@ from maskrcnn_benchmark.utils.registry import Registry
 
 BACKBONES = Registry()
 ROI_BOX_FEATURE_EXTRACTORS = Registry()
+RPN_HEADS = Registry()

--- a/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_feature_extractors.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_feature_extractors.py
@@ -2,10 +2,12 @@
 from torch import nn
 from torch.nn import functional as F
 
+from maskrcnn_benchmark.modeling import registry
 from maskrcnn_benchmark.modeling.backbone import resnet
 from maskrcnn_benchmark.modeling.poolers import Pooler
 
 
+@registry.ROI_BOX_FEATURE_EXTRACTORS.register("ResNet50Conv5ROIFeatureExtractor")
 class ResNet50Conv5ROIFeatureExtractor(nn.Module):
     def __init__(self, config):
         super(ResNet50Conv5ROIFeatureExtractor, self).__init__()
@@ -39,6 +41,7 @@ class ResNet50Conv5ROIFeatureExtractor(nn.Module):
         return x
 
 
+@registry.ROI_BOX_FEATURE_EXTRACTORS.register("FPN2MLPFeatureExtractor")
 class FPN2MLPFeatureExtractor(nn.Module):
     """
     Heads for FPN for classification
@@ -77,12 +80,8 @@ class FPN2MLPFeatureExtractor(nn.Module):
         return x
 
 
-_ROI_BOX_FEATURE_EXTRACTORS = {
-    "ResNet50Conv5ROIFeatureExtractor": ResNet50Conv5ROIFeatureExtractor,
-    "FPN2MLPFeatureExtractor": FPN2MLPFeatureExtractor,
-}
-
-
 def make_roi_box_feature_extractor(cfg):
-    func = _ROI_BOX_FEATURE_EXTRACTORS[cfg.MODEL.ROI_BOX_HEAD.FEATURE_EXTRACTOR]
+    func = registry.ROI_BOX_FEATURE_EXTRACTORS[
+        cfg.MODEL.ROI_BOX_HEAD.FEATURE_EXTRACTOR
+    ]
     return func(cfg)

--- a/maskrcnn_benchmark/utils/registry.py
+++ b/maskrcnn_benchmark/utils/registry.py
@@ -1,0 +1,45 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+
+def _register_generic(module_dict, module_name, module):
+    assert module_name not in module_dict
+    module_dict[module_name] = module
+
+
+class Registry(dict):
+    '''
+    A helper class for managing registering modules, it extends a dictionary
+    and provides a register functions.
+
+    Eg. creeting a registry:
+        some_registry = Registry({"default": default_module})
+
+    There're two ways of registering new modules:
+    1): normal way is just calling register function:
+        def foo():
+            ...
+        some_registry.register("foo_module", foo)
+    2): used as decorator when declaring the module:
+        @some_registry.register("foo_module")
+        @some_registry.register("foo_modeul_nickname")
+        def foo():
+            ...
+
+    Access of module is just like using a dictionary, eg:
+        f = some_registry["foo_modeul"]
+    '''
+    def __init__(self, *args, **kwargs):
+        super(Registry, self).__init__(*args, **kwargs)
+
+    def register(self, module_name, module=None):
+        # used as function call
+        if module is not None:
+            _register_generic(self, module_name, module)
+            return
+
+        # used as decorator
+        def register_fn(fn):
+            _register_generic(self, module_name, fn)
+            return fn
+
+        return register_fn


### PR DESCRIPTION
Adding a basic registration module for backbone and roi & rpn heads. For adding customized building blocks, one can write new functions/modules with `register` decorators in separate files.