### PR TITLE
Add returning encoding features of detected objects in RCNN

### DIFF
--- a/demo/roi_encoding.py
+++ b/demo/roi_encoding.py
@@ -60,7 +60,7 @@ class ImageLoader(object):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--base_path", "--base_path", help="Base path for images", required=True)
+    parser.add_argument("--base_path", "--base_path", help="Base path for images", default="/home/esoroush/tmp/imgs")#, required=True)
     parser.add_argument("--extension", help="Extensions of images", default="jpg")
     parser.add_argument("--batch_size", help="Batch size", default=5, type=int)
     parser.add_argument("--max_num_bbox", help="Maximum number of object bounding boxes for each image", default=36, type=int)

--- a/demo/roi_encoding.py
+++ b/demo/roi_encoding.py
@@ -14,7 +14,7 @@ import h5py
 
 
 join_path=lambda x: os.path.join(os.path.dirname(__file__),x)
-config_file = join_path("../configs/caffe2/e2e_faster_rcnn_R_50_FPN_1x_caffe2.yaml")
+config_file = join_path("../configs/caffe2/e2e_faster_rcnn_X_101_32x8d_FPN_1x_caffe2.yaml")
 
 # update the config options with the config file
 cfg.merge_from_file(config_file)
@@ -60,7 +60,7 @@ class ImageLoader(object):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--base_path", "--base_path", help="Base path for images", default="/home/esoroush/tmp/imgs")#, required=True)
+    parser.add_argument("--base_path", "--base_path", help="Base path for images", required=True)
     parser.add_argument("--extension", help="Extensions of images", default="jpg")
     parser.add_argument("--batch_size", help="Batch size", default=5, type=int)
     parser.add_argument("--max_num_bbox", help="Maximum number of object bounding boxes for each image", default=36, type=int)

--- a/demo/roi_encoding.py
+++ b/demo/roi_encoding.py
@@ -1,0 +1,88 @@
+"""
+A simple demo for extracting the encoding features of object bounding boxes
+in images and store it on an HDF5 file.
+This features can be used as bottom-up attention features in Image captioning described at [here](https://arxiv.org/abs/1707.07998)
+"""
+import cv2
+from maskrcnn_benchmark.config import cfg
+from predictor import COCODemo
+import os
+from glob import glob
+import argparse
+from math import ceil
+import h5py
+
+
+join_path=lambda x: os.path.join(os.path.dirname(__file__),x)
+config_file = join_path("../configs/caffe2/e2e_faster_rcnn_R_50_FPN_1x_caffe2.yaml")
+
+# update the config options with the config file
+cfg.merge_from_file(config_file)
+# manual override some options
+cfg.merge_from_list(["MODEL.DEVICE", "cuda"])
+
+coco_demo = COCODemo(
+    cfg,
+    min_image_size=800,
+    confidence_threshold=0.7,
+)
+
+class ImageLoader(object):
+    """
+    A simple class for batching images to extract encoded features.
+    """
+    def __init__(self, base_path, extension='jpg', batch_size=32):
+        self._base_path = base_path
+        self._images_path = glob(os.path.join(self._base_path, "*."+extension))
+        self._batch_size=batch_size
+        self._num_images=len(self._images_path)
+        self._total_batches=ceil(self._num_images/self._batch_size)
+        print("Number of images for object encoding: %d"%self._num_images)
+        if self._num_images == 0:
+            raise ValueError("No images exists in the base path. Maybe you had provided wrong path.")
+    
+    @property
+    def num_images(self):
+        return self._num_images
+
+    def __len__(self):
+        return len(self._images_path)
+    
+    def __getitem__(self, index):
+        return cv2.imread(self._images_path[index])
+    
+    def next_batch(self):
+        for i in range(self._total_batches):
+            batch_slice=range(i*self._batch_size,(i+1)*self._batch_size)
+            batch = [self[i] for i in batch_slice]
+            names = [self._images_path[i] for i in batch_slice]
+            yield batch, names
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base_path", "--base_path", help="Base path for images", required=True)
+    parser.add_argument("--extension", help="Extensions of images", default="jpg")
+    parser.add_argument("--batch_size", help="Batch size", default=5, type=int)
+    parser.add_argument("--max_num_bbox", help="Maximum number of object bounding boxes for each image", default=36, type=int)
+    parser.add_argument("--storing_path", help="Storing path of hdf5 file", default="encoding_features.h5")
+    encoding_dim=1024
+    args=parser.parse_args()
+    h_stores=h5py.File(args.storing_path, 'w')
+    image_loader=ImageLoader(args.base_path, extension=args.extension, batch_size=args.batch_size)
+    encoding_features=h_stores.create_dataset("encoding_features",shape=(image_loader.num_images, args.max_num_bbox, encoding_dim), dtype='f')
+    bboxes=h_stores.create_dataset("bboxes", shape=(image_loader.num_images, args.max_num_bbox,4), dtype='f')
+    image_names=h_stores.create_dataset("image_names", shape=(image_loader.num_images,), dtype=h5py.special_dtype(vlen=str))
+
+    index=0
+    for batch, names in image_loader.next_batch():
+        predictions = coco_demo.extract_encoding_features(batch)
+        for i,p in enumerate(predictions):
+            m = min(args.max_num_bbox, len(p.extra_fields['encoding_features']))
+            encoding_features[index,:m,:]=p.extra_fields['encoding_features'].numpy()[:m,:]
+            bboxes[index,:m-1,:]=p.bbox.numpy()[:m-1,:]
+            image_names[index]=names[i].split('/')[-1]
+            index+=1
+    h_stores.close()
+
+if __name__ == '__main__':
+    main()

--- a/maskrcnn_benchmark/modeling/detector/generalized_rcnn.py
+++ b/maskrcnn_benchmark/modeling/detector/generalized_rcnn.py
@@ -30,20 +30,18 @@ class GeneralizedRCNN(nn.Module):
         self.rpn = build_rpn(cfg)
         self.roi_heads = build_roi_heads(cfg)
 
-    def forward(self, images, targets=None, return_features=False):
+    def forward(self, images, targets=None):
         """
         Arguments:
             images (list[Tensor] or ImageList): images to be processed
             targets (list[BoxList]): ground-truth boxes present in the image (optional)
-            return_features (Bool): Determines wheter return the features
 
         Returns:
             result (list[BoxList] or dict[Tensor]): the output from the model.
                 During training, it returns a dict[Tensor] which contains the losses.
                 During testing, it returns list[BoxList] contains additional fields
-                like `scores`, `labels` and `mask` (for Mask R-CNN models).
-                If return_features is True, it also returns the encoded features as (list[Tensor])
-                where for each image its shape is [1000,1024].
+                like `scores`, `labels` and `mask` (for Mask R-CNN models), 
+                and `orig_inds' for preserving indices of filtered bboxes.
 
         """
         if self.training and targets is None:
@@ -64,7 +62,4 @@ class GeneralizedRCNN(nn.Module):
             losses.update(detector_losses)
             losses.update(proposal_losses)
             return losses
-        if return_features:
-            return result, x
-        else:
-            return result
+        return result

--- a/maskrcnn_benchmark/modeling/detector/generalized_rcnn.py
+++ b/maskrcnn_benchmark/modeling/detector/generalized_rcnn.py
@@ -30,17 +30,20 @@ class GeneralizedRCNN(nn.Module):
         self.rpn = build_rpn(cfg)
         self.roi_heads = build_roi_heads(cfg)
 
-    def forward(self, images, targets=None):
+    def forward(self, images, targets=None, return_features=False):
         """
         Arguments:
             images (list[Tensor] or ImageList): images to be processed
             targets (list[BoxList]): ground-truth boxes present in the image (optional)
+            return_features (Bool): Determines wheter return the features
 
         Returns:
             result (list[BoxList] or dict[Tensor]): the output from the model.
                 During training, it returns a dict[Tensor] which contains the losses.
                 During testing, it returns list[BoxList] contains additional fields
                 like `scores`, `labels` and `mask` (for Mask R-CNN models).
+                If return_features is True, it also returns the encoded features as (list[Tensor])
+                where for each image its shape is [1000,1024].
 
         """
         if self.training and targets is None:
@@ -61,5 +64,7 @@ class GeneralizedRCNN(nn.Module):
             losses.update(detector_losses)
             losses.update(proposal_losses)
             return losses
-
-        return result
+        if return_features:
+            return result, x
+        else:
+            return result

--- a/maskrcnn_benchmark/modeling/roi_heads/box_head/inference.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/box_head/inference.py
@@ -112,6 +112,7 @@ class PostProcessor(nn.Module):
             boxes_j = boxes[inds, j * 4 : (j + 1) * 4]
             boxlist_for_class = BoxList(boxes_j, boxlist.size, mode="xyxy")
             boxlist_for_class.add_field("scores", scores_j)
+            boxlist_for_class.add_field("orig_inds", inds) # preserve indices of encoded features for each bbox
             boxlist_for_class = boxlist_nms(
                 boxlist_for_class, self.nms, score_field="scores"
             )


### PR DESCRIPTION
It is a good idea to maintain the indices of filtered bboxes for RCNN detection.  
One application is to return representation or encoded features of each bbox in inference time.  

# Description
Preparing encoded features of detected objects and storing them into an HDF5 file.
These features are needed for bottom-up attention features described at [this paper](https://arxiv.org/abs/1707.07998)

# Requirements
`pip install h5py`

# Usage
To extract and store encoded features from objects in images in `folder_path` execute the following command:  
```bash
python demo/roi_encoding.py
```
The function in `COCODemo.extract_encoding_features` extract encoded features from detected objects exists in the input images.