### PR TITLE
Add posibility to setup DATA_DIR as env variable

### DIFF
--- a/maskrcnn_benchmark/config/paths_catalog.py
+++ b/maskrcnn_benchmark/config/paths_catalog.py
@@ -5,7 +5,7 @@ import os
 
 
 class DatasetCatalog(object):
-    DATA_DIR = "datasets"
+    DATA_DIR = "datasets" if "DATA_DIR" not in os.environ else os.environ["DATA_DIR"]
 
     DATASETS = {
         "coco_2014_train": (


### PR DESCRIPTION
Hi Francisco,

What do you think about such tweak to have a possibilty to setup DATA_DIR from the environment variable instead of symlinking folders into `datasets` as described in the README ?
