### PR TITLE
changed the order of the docker build command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,4 +64,4 @@ Build image with defaults (`CUDA=9.0`, `CUDNN=7`):
     
 Build image with other CUDA and CUDNN versions:
 
-    nvidia-docker build -t --build-arg CUDA=9.2 --build-arg CUDNN=7 maskrcnn-benchmark docker/ 
+    nvidia-docker build -t maskrcnn-benchmark --build-arg CUDA=9.2 --build-arg CUDNN=7 docker/ 


### PR DESCRIPTION
When using the docker build command in INSTALL.md:
`nvidia-docker build -t --build-arg CUDA=9.2 --build-arg CUDNN=7 maskrcnn-benchmark docker/ `

The following error occurs:
```
invalid argument "--build-arg" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
```

This happens because the order of the command is wrong. I changed the order of the command so that the error doesnt occur and the docker image can be built.