### PR TITLE
Fix indexing error in nms kernel

### DIFF
--- a/maskrcnn_benchmark/csrc/cuda/nms.cu
+++ b/maskrcnn_benchmark/csrc/cuda/nms.cu
@@ -124,5 +124,5 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
 
   THCudaFree(state, mask_dev);
   // TODO improve this part
-  return std::get<0>(order_t.index({keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep)}).sort(0, false));
+  return std::get<0>(order_t.index({keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).cuda()}).sort(0, false));
 }

--- a/maskrcnn_benchmark/csrc/cuda/nms.cu
+++ b/maskrcnn_benchmark/csrc/cuda/nms.cu
@@ -124,5 +124,8 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
 
   THCudaFree(state, mask_dev);
   // TODO improve this part
-  return std::get<0>(order_t.index({keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).cuda()}).sort(0, false));
+  return std::get<0>(order_t.index({
+                       keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(
+                         order_t.device(), keep.scalar_type())
+                     }).sort(0, false));
 }


### PR DESCRIPTION
Here it is indexing a cuda tensor with CPU indices. It used to work, but 
after https://github.com/pytorch/pytorch/commit/006505bb8f9dcf0f38b32518308d071c8a1ccec6 it results in memory corruption.