### PR TITLE
edited CUDA files to avoid Windows 10 build errors

### DIFF
--- a/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
@@ -11,6 +11,11 @@
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n; \
        i += blockDim.x * gridDim.x)
 
+/* added function */
+  int ceil_div(int a, int b){
+    return (a + b - 1) / b;
+  }
+
 
 template <typename T>
 __device__ T bilinear_interpolate(const T* bottom_data,
@@ -272,7 +277,10 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
   auto output_size = num_rois * pooled_height * pooled_width * channels;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(output_size, 512L), 4096L));
+  //changed
+
+  dim3 grid(std::min(ceil_div((int)output_size, 512), 4096));
+  // dim3 grid(std::min(THCCeilDiv(output_size, 512L), 4096L));
   dim3 block(512);
 
   if (output.numel() == 0) {
@@ -317,7 +325,8 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(grad.numel(), 512L), 4096L));
+  dim3 grid(std::min(ceil_div((int)grad.numel(), 512), 4096));
+  // dim3 grid(std::min(THCCeilDiv(grad.numel(), 512L), 4096L)); 
   dim3 block(512);
 
   // handle possibly empty gradients

--- a/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
@@ -6,12 +6,15 @@
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 
-
 // TODO make it in a common file
 #define CUDA_1D_KERNEL_LOOP(i, n)                            \
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n; \
        i += blockDim.x * gridDim.x)
 
+/* added function */
+  int ceil_div_2(int a, int b){
+    return (a + b - 1) / b;
+  }
 
 template <typename T>
 __global__ void RoIPoolFForward(const int nthreads, const T* bottom_data,
@@ -126,7 +129,8 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(output_size, 512L), 4096L));
+  dim3 grid(std::min(ceil_div_2((int)output_size, 512), 4096));
+  //dim3 grid(std::min(THCCeilDiv(output_size, 512L), 4096L));
   dim3 block(512);
 
   if (output.numel() == 0) {
@@ -173,7 +177,8 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(grad.numel(), 512L), 4096L));
+  dim3 grid(std::min(ceil_div_2((int)grad.numel(), 512), 4096));
+  //dim3 grid(std::min(THCCeilDiv(grad.numel(), 512L), 4096L));
   dim3 block(512);
 
   // handle possibly empty gradients


### PR DESCRIPTION
As per issue 254: https://github.com/facebookresearch/maskrcnn-benchmark/issues/254

Added functions to replace THCeilDiv function in ROIAlign and ROIPool, successfully builds on Windows 10.