### PR TITLE
Fix error in MetricLogger for non-existing attributes

### DIFF
--- a/maskrcnn_benchmark/utils/metric_logger.py
+++ b/maskrcnn_benchmark/utils/metric_logger.py
@@ -52,7 +52,10 @@ class MetricLogger(object):
     def __getattr__(self, attr):
         if attr in self.meters:
             return self.meters[attr]
-        return object.__getattr__(self, attr)
+        if attr in self.__dict__:
+            return self.__dict__[attr]
+        raise AttributeError("'{}' object has no attribute '{}'".format(
+                    type(self).__name__, attr))
 
     def __str__(self):
         loss_str = []

--- a/tests/test_metric_logger.py
+++ b/tests/test_metric_logger.py
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+import unittest
+
+from maskrcnn_benchmark.utils.metric_logger import MetricLogger
+
+
+class TestMetricLogger(unittest.TestCase):
+    def test_update(self):
+        meter = MetricLogger()
+        for i in range(10):
+            meter.update(metric=float(i))
+        
+        m = meter.meters["metric"]
+        self.assertEqual(m.count, 10)
+        self.assertEqual(m.total, 45)
+        self.assertEqual(m.median, 4)
+        self.assertEqual(m.avg, 4.5)
+
+    def test_no_attr(self):
+        meter = MetricLogger()
+        _ = meter.meters
+        _ = meter.delimiter
+        def broken():
+            _ = meter.not_existent
+        self.assertRaises(AttributeError, broken)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/maskrcnn-benchmark/issues/278