### PR TITLE
fixup cv2.findContours to only return 2 values

### DIFF
--- a/demo/predictor.py
+++ b/demo/predictor.py
@@ -287,7 +287,7 @@ class COCODemo(object):
 
         for mask, color in zip(masks, colors):
             thresh = mask[0, :, :, None]
-            _, contours, hierarchy = cv2.findContours(
+            contours, hierarchy = cv2.findContours(
                 thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
             )
             image = cv2.drawContours(image, contours, -1, color, 3)


### PR DESCRIPTION
This PR is to fix an error that I ran in to when running [demo/Mask_R-CNN_demo.ipynb](https://github.com/facebookresearch/maskrcnn-benchmark/blob/master/demo/Mask_R-CNN_demo.ipynb)

The PR removes the first `_` assigned variable. Based on the docs for opencv `cv2.findContours` only returns 2 values. Here's the docs link:

[https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#gadf1ad6a0b82947fa1fe3c3d497f260e0](https://docs.opencv.org/master/d3/dc0/group__imgproc__shape.html#gadf1ad6a0b82947fa1fe3c3d497f260e0
)

Here is the stack trace that I got from the current code on *master*:

```
ValueError                                Traceback (most recent call last)
<ipython-input-10-ba06eae97bcc> in <module>
      1 # compute predictions
----> 2 predictions = coco_demo.run_on_opencv_image(image)
      3 imshow(predictions)

~/github/maskrcnn-benchmark/demo/predictor.py in run_on_opencv_image(self, image)
    177         result = self.overlay_boxes(result, top_predictions)
    178         if self.cfg.MODEL.MASK_ON:
--> 179             result = self.overlay_mask(result, top_predictions)
    180         result = self.overlay_class_names(result, top_predictions)
    181 

~/github/maskrcnn-benchmark/demo/predictor.py in overlay_mask(self, image, predictions)
    289             thresh = mask[0, :, :, None]
    290             _, contours, hierarchy = cv2.findContours(
--> 291                 thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
    292             )
    293             image = cv2.drawContours(image, contours, -1, color, 3)

ValueError: not enough values to unpack (expected 3, got 2)
```

I was using these package versions when I ran into the error:

```
Python 3.6.7
opencv-python==4.0.0.21
```