### PR TITLE
a Python 2-3 compatibility issue in lr_scheduler.py

### DIFF
--- a/maskrcnn_benchmark/solver/lr_scheduler.py
+++ b/maskrcnn_benchmark/solver/lr_scheduler.py
@@ -42,7 +42,7 @@ class WarmupMultiStepLR(torch.optim.lr_scheduler._LRScheduler):
             if self.warmup_method == "constant":
                 warmup_factor = self.warmup_factor
             elif self.warmup_method == "linear":
-                alpha = self.last_epoch / self.warmup_iters
+                alpha = float(self.last_epoch) / self.warmup_iters
                 warmup_factor = self.warmup_factor * (1 - alpha) + alpha
         return [
             base_lr


### PR DESCRIPTION
PR for the [issue warmup linear problem](https://github.com/facebookresearch/maskrcnn-benchmark/issues/335) to the Python 2-3 compatibility issue.

![image](https://user-images.githubusercontent.com/22321977/51117707-82581280-1849-11e9-97ed-ae22e7c31fed.png)
