### PR TITLE
Add helper function "cv2_utils.findContours" to maintain version compatibility between versions 3 and 4

### DIFF
--- a/demo/predictor.py
+++ b/demo/predictor.py
@@ -8,6 +8,7 @@ from maskrcnn_benchmark.utils.checkpoint import DetectronCheckpointer
 from maskrcnn_benchmark.structures.image_list import to_image_list
 from maskrcnn_benchmark.modeling.roi_heads.mask_head.inference import Masker
 from maskrcnn_benchmark import layers as L
+from maskrcnn_benchmark.utils import cv2_util
 
 
 class COCODemo(object):
@@ -287,7 +288,7 @@ class COCODemo(object):
 
         for mask, color in zip(masks, colors):
             thresh = mask[0, :, :, None]
-            _, contours, hierarchy = cv2.findContours(
+            contours, hierarchy = cv2_util.findContours(
                 thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
             )
             image = cv2.drawContours(image, contours, -1, color, 3)

--- a/maskrcnn_benchmark/utils/cv2_util.py
+++ b/maskrcnn_benchmark/utils/cv2_util.py
@@ -1,0 +1,24 @@
+"""
+Module for cv2 utility functions and maintaining version compatibility
+between 3.x and 4.x
+"""
+import cv2
+
+
+def findContours(*args, **kwargs):
+    """
+    Wraps cv2.findContours to maintain compatiblity between versions
+    3 and 4
+
+    Returns:
+        contours, hierarchy
+    """
+    if cv2.__version__.startswith('4'):
+        contours, hierarchy = cv2.findContours(*args, **kwargs)
+    elif cv2.__version__.startswith('3'):
+        _, contours, hierarchy = cv2.findContours(*args, **kwargs)
+    else:
+        raise AssertionError(
+            'cv2 must be either version 3 or 4 to call this method')
+
+    return contours, hierarchy

--- a/tools/cityscapes/instances2dict_with_polygons.py
+++ b/tools/cityscapes/instances2dict_with_polygons.py
@@ -13,6 +13,8 @@ from csHelpers import *
 from cityscapesscripts.evaluation.instance import *
 from cityscapesscripts.helpers.csHelpers import *
 import cv2
+from maskrcnn_benchmark.utils import cv2_util
+
 
 def instances2dict_with_polygons(imageFileList, verbose=False):
     imgCount     = 0
@@ -46,7 +48,7 @@ def instances2dict_with_polygons(imageFileList, verbose=False):
             #instances[id2label[instanceObj.labelID].name].append(instanceObj.toDict())
             if id2label[instanceObj.labelID].hasInstances:
                 mask = (imgNp == instanceId).astype(np.uint8)
-                im2, contour, hier = cv2.findContours(
+                contour, hier = cv2_util.findContours(
                     mask.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
 
                 polygons = [c.reshape(-1).tolist() for c in contour]


### PR DESCRIPTION
## Summary

Small PR to fix the version compatibility problem with `cv2.findContours` returning either 2 or 3 values depending on the cv2 version.

I replaced all occurrences of `cv2.findContours` with the helper.

I put the code in `utils/` dir. Seemed like the best place for it, but please advise.

## Testing

I tested locally by installing my branch locally using:

```
pip install -U git+https://github.com/aaronlelevier/maskrcnn-benchmark.git@train
```

Then ran the `demo/Mask_R-CNN_demo.ipynb ` and it worked as expected, even though my `cv2` version is `opencv-python==4.0.0.21`, so this is now compatible with either version.


## References

fixes #336 

#339 also referenced this error but the issue is already closed 
