### PR TITLE
Revert "swich to new pytorch api"

### DIFF
--- a/maskrcnn_benchmark/modeling/rpn/loss.py
+++ b/maskrcnn_benchmark/modeling/rpn/loss.py
@@ -126,7 +126,7 @@ class RPNLossComputation(object):
             box_regression[sampled_pos_inds],
             regression_targets[sampled_pos_inds],
             beta=1.0 / 9,
-            reduction='sum',
+            size_average=False,
         ) / (sampled_inds.numel())
 
         objectness_loss = F.binary_cross_entropy_with_logits(


### PR DESCRIPTION
Reverts facebookresearch/maskrcnn-benchmark#359

Fixes https://github.com/facebookresearch/maskrcnn-benchmark/issues/363

There should have been a change in the `layers/smooth_l1_loss.py` as well. Reverting this change.