### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ def get_extensions():
             include_dirs=include_dirs,
             define_macros=define_macros,
             extra_compile_args=extra_compile_args,
+            extra_link_args=['-L/usr/lib/x86_64-linux-gnu/'],
         )
     ]
 


### PR DESCRIPTION
When using gcc/g++ from anaconda environment, we should add this into setup.py, so that we can successfully build the project.

If we do not add, the compilation will fail.