### PR TITLE
Add COCO_2017 in paths_catalog.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,18 @@ ln -s /path_to_coco_dataset/annotations datasets/coco/annotations
 ln -s /path_to_coco_dataset/train2014 datasets/coco/train2014
 ln -s /path_to_coco_dataset/test2014 datasets/coco/test2014
 ln -s /path_to_coco_dataset/val2014 datasets/coco/val2014
+# or use COCO 2017 version
+ln -s /path_to_coco_dataset/annotations datasets/coco/annotations
+ln -s /path_to_coco_dataset/train2017 datasets/coco/train2017
+ln -s /path_to_coco_dataset/test2017 datasets/coco/test2017
+ln -s /path_to_coco_dataset/val2017 datasets/coco/val2017
+
 # for pascal voc dataset:
 ln -s /path_to_VOCdevkit_dir datasets/voc
 ```
+
+P.S. `COCO_2017_train` = `COCO_2014_train` + `valminusminival` , `COCO_2017_val` = `minival`
+      
 
 You can also configure your own paths to the datasets.
 For that, all you need to do is to modify `maskrcnn_benchmark/config/paths_catalog.py` to

--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ note = {Accessed: [Insert date here]}
 
 ## Projects using maskrcnn-benchmark
 
-- [RetinaMask: Learning to predict masks improves state-of-the-art single-shot detection for free](https://arxiv.org/abs/1901.03353).
-  Cheng-Yang Fu, Mykhailo Shvets, and Alexander C. Berg
-  Tech report, arXiv,1901.03353.
+- [RetinaMask: Learning to predict masks improves state-of-the-art single-shot detection for free](https://arxiv.org/abs/1901.03353). <br>
+  Cheng-Yang Fu, Mykhailo Shvets, and Alexander C. Berg <br>
+  Tech report, arXiv,1901.03353. <br>
 
 
 

--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ note = {Accessed: [Insert date here]}
 
 ## Projects using maskrcnn-benchmark
 
-- [RetinaMask: Learning to predict masks improves state-of-the-art single-shot detection for free](https://arxiv.org/abs/1901.03353). <br>
-  Cheng-Yang Fu, Mykhailo Shvets, and Alexander C. Berg <br>
-  Tech report, arXiv,1901.03353. <br>
+- [RetinaMask: Learning to predict masks improves state-of-the-art single-shot detection for free](https://arxiv.org/abs/1901.03353). 
+  Cheng-Yang Fu, Mykhailo Shvets, and Alexander C. Berg.
+  Tech report, arXiv,1901.03353.
 
 
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ note = {Accessed: [Insert date here]}
 }
 ```
 
+## Projects using maskrcnn-benchmark
+
+- [RetinaMask: Learning to predict masks improves state-of-the-art single-shot detection for free](https://arxiv.org/abs/1901.03353).
+  Cheng-Yang Fu, Mykhailo Shvets, and Alexander C. Berg
+  Tech report, arXiv,1901.03353.
+
+
+
 ## License
 
 maskrcnn-benchmark is released under the MIT license. See [LICENSE](LICENSE) for additional details.

--- a/maskrcnn_benchmark/config/paths_catalog.py
+++ b/maskrcnn_benchmark/config/paths_catalog.py
@@ -7,6 +7,14 @@ import os
 class DatasetCatalog(object):
     DATA_DIR = "datasets"
     DATASETS = {
+        "coco_2017_train": {
+            "img_dir": "coco/train2017",
+            "ann_file": "coco/annotations/instances_train2017.json"
+        },
+        "coco_2017_val": {
+            "img_dir": "coco/val2017",
+            "ann_file": "coco/annotations/instances_val2017.json"
+        },
         "coco_2014_train": {
             "img_dir": "coco/train2014",
             "ann_file": "coco/annotations/instances_train2014.json"


### PR DESCRIPTION
Add the COCO_2017 link. In 2017, COCO changed the train/val splits based the research community feedback.
`COCO_2017_train` = `COCO_2014_train` + `valminusminival`
`COCO_2017_val` = `minival`

This just makes the setting of COCO simpler and does not need to download the annotations outside the COCO website. It will also be useful for combing the stuff annotation in the future. 