### PR TITLE
Fix `NameError: name 'cfg' is not defined` in roi_box_predictors.py

### DIFF
--- a/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py
@@ -14,7 +14,7 @@ class FastRCNNPredictor(nn.Module):
         num_classes = config.MODEL.ROI_BOX_HEAD.NUM_CLASSES
         self.avgpool = nn.AvgPool2d(kernel_size=7, stride=7)
         self.cls_score = nn.Linear(num_inputs, num_classes)
-        num_bbox_reg_classes = 2 if cfg.MODEL.CLS_AGNOSTIC_BBOX_REG else num_classes
+        num_bbox_reg_classes = 2 if config.MODEL.CLS_AGNOSTIC_BBOX_REG else num_classes
         self.bbox_pred = nn.Linear(num_inputs, num_bbox_reg_classes * 4)
 
         nn.init.normal_(self.cls_score.weight, mean=0, std=0.01)


### PR DESCRIPTION
I get the following error when execute `tools/train_net.py`:

```
Traceback (most recent call last):
  File "tools/train_net.py", line 172, in <module>
    main()
  File "tools/train_net.py", line 165, in main
    model = train(cfg, args.local_rank, args.distributed)
  File "tools/train_net.py", line 30, in train
    model = build_detection_model(cfg)
  File "/content/maskrcnn-benchmark/maskrcnn_benchmark/modeling/detector/detectors.py", line 10, in build_detection_model
    return meta_arch(cfg)
  File "/content/maskrcnn-benchmark/maskrcnn_benchmark/modeling/detector/generalized_rcnn.py", line 31, in __init__
    self.roi_heads = build_roi_heads(cfg)
  File "/content/maskrcnn-benchmark/maskrcnn_benchmark/modeling/roi_heads/roi_heads.py", line 46, in build_roi_heads
    roi_heads.append(("box", build_roi_box_head(cfg)))
  File "/content/maskrcnn-benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/box_head.py", line 70, in build_roi_box_head
    return ROIBoxHead(cfg)
  File "/content/maskrcnn-benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/box_head.py", line 19, in __init__
    self.predictor = make_roi_box_predictor(cfg)
  File "/content/maskrcnn-benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py", line 64, in make_roi_box_predictor
    return func(cfg)
  File "/content/maskrcnn-benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py", line 17, in __init__
    num_bbox_reg_classes = 2 if cfg.MODEL.CLS_AGNOSTIC_BBOX_REG else num_classes
NameError: name 'cfg' is not defined
```
This is caused by typo for `config`. 