### PR TITLE
Replace with get_img_info on coco_eval

### DIFF
--- a/maskrcnn_benchmark/data/datasets/evaluation/coco/coco_eval.py
+++ b/maskrcnn_benchmark/data/datasets/evaluation/coco/coco_eval.py
@@ -72,9 +72,9 @@ def prepare_for_coco_detection(predictions, dataset):
         if len(prediction) == 0:
             continue
 
-        # TODO replace with get_img_info?
-        image_width = dataset.coco.imgs[original_id]["width"]
-        image_height = dataset.coco.imgs[original_id]["height"]
+        img_info = dataset.get_img_info(image_id)
+        image_width = img_info["width"]
+        image_height = img_info["height"]
         prediction = prediction.resize((image_width, image_height))
         prediction = prediction.convert("xywh")
 
@@ -110,9 +110,9 @@ def prepare_for_coco_segmentation(predictions, dataset):
         if len(prediction) == 0:
             continue
 
-        # TODO replace with get_img_info?
-        image_width = dataset.coco.imgs[original_id]["width"]
-        image_height = dataset.coco.imgs[original_id]["height"]
+        img_info = dataset.get_img_info(image_id)
+        image_width = img_info["width"]
+        image_height = img_info["height"]
         prediction = prediction.resize((image_width, image_height))
         masks = prediction.get_field("mask")
         # t = time.time()
@@ -190,9 +190,9 @@ def evaluate_box_proposals(
     for image_id, prediction in enumerate(predictions):
         original_id = dataset.id_to_img_map[image_id]
 
-        # TODO replace with get_img_info?
-        image_width = dataset.coco.imgs[original_id]["width"]
-        image_height = dataset.coco.imgs[original_id]["height"]
+        img_info = dataset.get_img_info(image_id)
+        image_width = img_info["width"]
+        image_height = img_info["height"]
         prediction = prediction.resize((image_width, image_height))
 
         # sort predictions in descending order


### PR DESCRIPTION
I was writing a script and saw some of these TODOs on `coco_eval.py` and I agree that using `get_img_info(...)` should be preferred. As they were straightforward to implement, here we are. I kept the same "style" used on [voc_eval.py](https://github.com/facebookresearch/maskrcnn-benchmark/blob/master/maskrcnn_benchmark/data/datasets/evaluation/voc/voc_eval.py#L18-L22). I performed an evaluation before and after the changes and I had no problems, as expected.

Although the TODOs seemed to be related only with the `width` and `height`, if we could assume that `dataset` is an instance of `COCODataset`, we could also change `original_id` to `img_info["id"]`. I was not sure about this assumption, because there are `assert`s in the beginning of these functions that are commented out.