### PR TITLE
 Replaced hard coding for shuffle variable

### DIFF
--- a/maskrcnn_benchmark/data/samplers/distributed.py
+++ b/maskrcnn_benchmark/data/samplers/distributed.py
@@ -37,7 +37,7 @@ class DistributedSampler(Sampler):
         self.epoch = 0
         self.num_samples = int(math.ceil(len(self.dataset) * 1.0 / self.num_replicas))
         self.total_size = self.num_samples * self.num_replicas
-        self.shuffle = True
+        self.shuffle = shuffle
 
     def __iter__(self):
         if self.shuffle:


### PR DESCRIPTION
Issue #437 

Replaced hardcoded value of shuffle with `self.shuffle = shuffle` 