### PR TITLE
clarifying directory structure and fixing typo

### DIFF
--- a/maskrcnn_benchmark/data/README.md
+++ b/maskrcnn_benchmark/data/README.md
@@ -70,19 +70,22 @@ ln -s /path/to/cityscapes datasets/data/cityscapes
 1. Download gtFine_trainvaltest.zip from https://www.cityscapes-dataset.com/downloads/ (login required)
 2. Extract it to /path/to/gtFine_trainvaltest
 ```
-gtFine_trainvaltest
-|_ gtFine
+cityscapes
+|_ gtFine_trainvaltest.zip
+|_ gtFine_trainvaltest
+   |_ gtFine
 ```
 3. Run the below commands to convert the annotations
+**NOTE: Detectron AND maskrcnn_benchmark is required**
 
 ```
 cd ~/github
 git clone https://github.com/mcordts/cityscapesScripts.git
 cd cityscapesScripts
-cp ~/github/maskrcnn-benchmark/tool/cityscapes/instances2dict_with_polygons.py cityscapesscripts/evaluation
+cp ~/github/maskrcnn-benchmark/tools/cityscapes/instances2dict_with_polygons.py cityscapesscripts/evaluation
 python setup.py install
 cd ~/github/maskrcnn-benchmark
-python tools/cityscapes/convert_cityscapes_to_coco.py --datadir /path/to/gtFine_trainvaltest --outdir /path/to/cityscapes/annotations
+python tools/cityscapes/convert_cityscapes_to_coco.py --datadir /path/to/cityscapes --outdir /path/to/cityscapes/annotations
 ```
 
 Example configuration files for Cityscapes could be found [here](https://github.com/facebookresearch/maskrcnn-benchmark/blob/master/configs/cityscapes/).


### PR DESCRIPTION
A few addition:
I added the top level directory `cityscapes` since the `tools/cityscapes/convert_cityscapes_to_coco.py` script has the directory structure `gtFine_trainvaltest/gtFine` hardcoded into it which is fine but was not clear at first.

Also added a **Note** to warn people to install detectron as well, since the script uses `detectron.utils.boxes` and `detectron.utils.segm` modules which has further dependencies in the detectron lib.