### PR TITLE
unsets proper variable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ cd maskrcnn-benchmark
 # re-build it
 python setup.py build develop
 
-unset MASKRCNN_BENCHMARK_INSTALL_DIR
+unset INSTALL_DIR
 
 # or if you are on macOS
 # MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py build develop


### PR DESCRIPTION
Finishing the clean up in https://github.com/facebookresearch/maskrcnn-benchmark/pull/455, unsetting the proper variable. 

In general, thanks for making this so easy to install! I'd run into all kinds of versioning issues (version of Ubuntu not playing nicely with versions of CUDA/pytorch/libraries) trying to install other libraries implementing these algorithms. I'm super impressed by the quality of support, and the easy install, for this library.