### PR TITLE
 Remove Detectron dependency

### DIFF
--- a/tools/cityscapes/convert_cityscapes_to_coco.py
+++ b/tools/cityscapes/convert_cityscapes_to_coco.py
@@ -29,8 +29,6 @@ import os
 import scipy.misc
 import sys
 
-import pdb
-
 import cityscapesscripts.evaluation.instances2dict_with_polygons as cs
 
 
@@ -152,7 +150,7 @@ def convert_cityscapes_instance_only(
         'motorcycle',
         'bicycle',
     ]
-#    pdb.set_trace()
+    
     for data_set, ann_dir in zip(sets, ann_dirs):
         print('Starting %s' % data_set)
         ann_dict = {}
@@ -210,11 +208,7 @@ def convert_cityscapes_instance_only(
                             ann['category_id'] = category_dict[object_cls]
                             ann['iscrowd'] = 0
                             ann['area'] = obj['pixelCount']
-                            '''
-                            ann['bbox'] = bboxs_util.xyxy_to_xywh(
-                                segms_util.polys_to_boxes(
-                                    [ann['segmentation']])).tolist()[0]
-                            '''
+                            
                             xyxy_box = poly_to_box(ann['segmentation'])
                             xywh_box = xyxy_to_xywh(xyxy_box)
                             ann['bbox'] = xywh_box

--- a/tools/cityscapes/convert_cityscapes_to_coco.py
+++ b/tools/cityscapes/convert_cityscapes_to_coco.py
@@ -150,14 +150,14 @@ def convert_cityscapes_instance_only(
         'motorcycle',
         'bicycle',
     ]
-    
+
     for data_set, ann_dir in zip(sets, ann_dirs):
         print('Starting %s' % data_set)
         ann_dict = {}
         images = []
         annotations = []
         ann_dir = os.path.join(data_dir, ann_dir)
-        print('ann_dir: %15s'%ann_dir)
+
         for root, _, files in os.walk(ann_dir):
             for filename in files:
                 if filename.endswith(ends_in % data_set.split('_')[0]):


### PR DESCRIPTION
Contribution to CityScapes -> COCO converter, following up on #447 .


I have looked into the boxes.py to swap [these lines](https://github.com/facebookresearch/Detectron/blob/8170b25b425967f8f1c7d715bea3c5b8d9536cd8/detectron/utils/boxes.py#L51L52):
```
import detectron.utils.cython_bbox as cython_bbox
import detectron.utils.cython_nms as cython_nms
```

```
from maskrcnn_benchmark.structures.boxlist_ops import boxlist_iou
from maskrcnn_benchmark.structures.boxlist_ops import boxlist_nms
```
However some functions are missing from the `boxlist_ops` like the [`soft_nms`](https://github.com/facebookresearch/Detectron/blob/master/detectron/utils/cython_nms.pyx#L98L203) .

So I just tried to modify the `maskrcnn-benchmark/tools/cityscapes/convert_cityscapes_to_coco.py` script.
Here we have `polys_to_boxes` function from `segms.py` and I could not find its analogous in the maskrcnn_benchmark lib. It seems to me that the original function in `segms.py` is using pure lists, while for the BoxList.convert I had to create a new entity for each object.

Seeing that the whole box is finally converted back to native python list seemed to have huge overhead, so I just wrote two auxiliary functions reusing the boxList's convert method( https://github.com/facebookresearch/maskrcnn-benchmark/blob/master/maskrcnn_benchmark/structures/bounding_box.py#L67L70 )
and Detectron's polys_to_boxes ( https://github.com/facebookresearch/Detectron/blob/b5dcc0fe1d091cb70f9243939258215dd63e3dfa/detectron/utils/segms.py#L135L140 ) to be applicable to a single instance:
```
def poly_to_box(poly):
    """Convert a polygon into a tight bounding box."""
    x0 = min(min(p[::2]) for p in poly)
    x1 = max(max(p[::2]) for p in poly)
    y0 = min(min(p[1::2]) for p in poly)
    y1 = max(max(p[1::2]) for p in poly)
    box_from_poly = [x0, y0, x1, y1]

    return box_from_poly

def xyxy_to_xywh(xyxy_box):
    xmin, ymin, xmax, ymax = xyxy_box
    TO_REMOVE = 1
    xywh_box = (xmin, ymin, xmax - xmin + TO_REMOVE, ymax - ymin + TO_REMOVE)
    return xywh_box
```
The upside of this solution that it uses native python lists so there is less overhead (if that counts here).

I haved tested it in a fresh conda environment using only the `maskrcnn_benchmark` install and it has been producing the same output as the previous.