### PR TITLE
change test() to run_test()

### DIFF
--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -76,7 +76,7 @@ def train(cfg, local_rank, distributed):
     return model
 
 
-def test(cfg, model, distributed):
+def run_test(cfg, model, distributed):
     if distributed:
         model = model.module
     torch.cuda.empty_cache()  # TODO check if it helps
@@ -167,7 +167,7 @@ def main():
     model = train(cfg, args.local_rank, args.distributed)
 
     if not args.skip_test:
-        test(cfg, model, args.distributed)
+        run_test(cfg, model, args.distributed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I'm using pycharm to debug the code on a remote server, the remote debugging seems to be performed by pytest and it pops errors like:

> train_net.py E
> test setup failed
> file /tmp/pycharm_project_269/tools/train_net.py, line 79
>   def test(cfg, model, distributed):
> E       fixture 'cfg' not found
> >       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
> >       use 'pytest --fixtures [testpath]' for help on them.


it seems the function name ‘test()’ has come conflict with pytest, so it may be better use another name.