### PR TITLE
Support for running on arbitrary CUDA device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,24 @@ predictions = coco_demo.run_on_opencv_image(image)
 
 ### Use it on an arbitrary GPU device
 For some cases, while multi-GPU devices are installed in a machine, a possible situation is that 
-we only have accesse to a specified GPU device (e.g. CUDA:1 or CUDA:2) for inference, testing or training.
+we only have accesse to a specified GPU device (e.g. CUDA:1 or CUDA:2) for inference, testing or training. 
+Here, the repository currently supports two methods to control devices.
 
+#### 1. using CUDA_VISIBLE_DEVICES environment variable (Recommend)
 Here is an example for Mask R-CNN R-50 FPN quick on the second device (CUDA:1):
 ```bash
-# for training
-python tools/train_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_50_FPN_quick.yaml MODEL.DEVICE cuda:1
-# for testing
-python tools/test_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_50_FPN_quick.yaml MODEL.DEVICE cuda:1
+export CUDA_VISIBLE_DEVICES=1
+python tools/train_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_50_FPN_quick.yaml
 ```
-Where, we add a `MODEL.DEVICE cuda:1` flag to specify the target device running the program.
+Now, the session will be totally loaded on the second GPU device (CUDA:1).
+
+#### 2. using MODEL.DEVICE flag
+In addition, the program could run on a sepcific GPU device by setting `MODEL.DEVICE` flag.
+```bash
+python tools/train_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_50_FPN_quick.yaml MODEL.DEVICE cuda:1
+```
+Where, we add a `MODEL.DEVICE cuda:1` flag to configure the target device. 
+*Pay attention, there is still a small part of memory stored in `cuda:0` for some reasons.*
 
 ## Perform training on COCO dataset
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ image = ...
 predictions = coco_demo.run_on_opencv_image(image)
 ```
 
+### Use it on a arbitrary GPU device
+For some cases, while multi-GPU devices are installed in a machine, a possible situation is that 
+we only have accesse to a specified GPU device (e.g. CUDA:1 or CUDA:2) for inference, testing and training.
+
+Here is an example for Mask R-CNN R-50 FPN quick on the second device (CUDA:1):
+```bash
+# for training
+python tools/train_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_50_FPN_quick.yaml MODEL.DEVICE cuda:1
+# for testing
+python tools/test_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_50_FPN_quick.yaml MODEL.DEVICE cuda:1
+```
+Where, we add a `MODEL.DEVICE cuda:1` hint to specify the target device running the program.
+
 ## Perform training on COCO dataset
 
 For the following examples to work, you need to first install `maskrcnn_benchmark`.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ image = ...
 predictions = coco_demo.run_on_opencv_image(image)
 ```
 
-### Use it on a arbitrary GPU device
+### Use it on an arbitrary GPU device
 For some cases, while multi-GPU devices are installed in a machine, a possible situation is that 
-we only have accesse to a specified GPU device (e.g. CUDA:1 or CUDA:2) for inference, testing and training.
+we only have accesse to a specified GPU device (e.g. CUDA:1 or CUDA:2) for inference, testing or training.
 
 Here is an example for Mask R-CNN R-50 FPN quick on the second device (CUDA:1):
 ```bash
@@ -79,7 +79,7 @@ python tools/train_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_
 # for testing
 python tools/test_net.py --config-file=configs/quick_schedules/e2e_mask_rcnn_R_50_FPN_quick.yaml MODEL.DEVICE cuda:1
 ```
-Where, we add a `MODEL.DEVICE cuda:1` hint to specify the target device running the program.
+Where, we add a `MODEL.DEVICE cuda:1` flag to specify the target device running the program.
 
 ## Perform training on COCO dataset
 

--- a/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
@@ -263,9 +263,7 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(input.get_device()));
+  CUDAGuard device_guard(input.device());
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
@@ -299,7 +297,6 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
          output.data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return output;
 }
 
@@ -316,10 +313,7 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
                                   const int sampling_ratio) {
   AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
-
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(grad.get_device()));
+  CUDAGuard device_guard(grad.device());
 
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
@@ -351,6 +345,5 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
          rois.contiguous().data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return grad_input;
 }

--- a/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
@@ -263,10 +263,6 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(input.get_device()));
-
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
@@ -299,7 +295,6 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
          output.data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return output;
 }
 
@@ -316,10 +311,6 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
                                   const int sampling_ratio) {
   AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
-
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(grad.get_device()));
 
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
@@ -351,6 +342,5 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
          rois.contiguous().data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return grad_input;
 }

--- a/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
@@ -263,6 +263,10 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
+  int current_device;
+  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(cudaSetDevice(input.get_device()));
+
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
@@ -295,6 +299,7 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
          output.data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
+  THCudaCheck(cudaSetDevice(current_device));
   return output;
 }
 
@@ -311,6 +316,10 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
                                   const int sampling_ratio) {
   AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
+
+  int current_device;
+  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(cudaSetDevice(grad.get_device()));
 
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
@@ -342,5 +351,6 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
          rois.contiguous().data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
+  THCudaCheck(cudaSetDevice(current_device));
   return grad_input;
 }

--- a/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
@@ -1,6 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGuard.h>
 
 #include <THC/THC.h>
 #include <THC/THCAtomics.cuh>
@@ -263,7 +264,7 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
-  CUDAGuard device_guard(input.device());
+  at::cuda::CUDAGuard device_guard(input.device());
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
@@ -313,7 +314,7 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
                                   const int sampling_ratio) {
   AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
-  CUDAGuard device_guard(grad.device());
+  at::cuda::CUDAGuard device_guard(grad.device());
 
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());

--- a/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
@@ -115,9 +115,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(input.get_device()));
+  CUDAGuard device_guard(input.device());
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
@@ -153,7 +151,6 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
          argmax.data<int>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return std::make_tuple(output, argmax);
 }
 
@@ -172,10 +169,7 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
   AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
   // TODO add more checks
-
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(grad.get_device()));
+  CUDAGuard device_guard(grad.device());
 
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
@@ -207,6 +201,5 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
          rois.contiguous().data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return grad_input;
 }

--- a/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
@@ -115,10 +115,6 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(input.get_device()));
-
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
@@ -153,7 +149,6 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
          argmax.data<int>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return std::make_tuple(output, argmax);
 }
 
@@ -173,10 +168,6 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
   // TODO add more checks
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(grad.get_device()));
-  
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
 
@@ -207,6 +198,5 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
          rois.contiguous().data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return grad_input;
 }

--- a/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
@@ -1,6 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGuard.h>
 
 #include <THC/THC.h>
 #include <THC/THCAtomics.cuh>
@@ -115,7 +116,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
-  CUDAGuard device_guard(input.device());
+  at::cuda::CUDAGuard device_guard(input.device());
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
@@ -169,7 +170,7 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
   AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
   // TODO add more checks
-  CUDAGuard device_guard(grad.device());
+  at::cuda::CUDAGuard device_guard(grad.device());
 
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());

--- a/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
@@ -115,6 +115,10 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
   AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
 
+  int current_device;
+  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(cudaSetDevice(input.get_device()));
+
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
@@ -149,6 +153,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
          argmax.data<int>());
   });
   THCudaCheck(cudaGetLastError());
+  THCudaCheck(cudaSetDevice(current_device));
   return std::make_tuple(output, argmax);
 }
 
@@ -167,6 +172,10 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
   AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
   AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
   // TODO add more checks
+
+  int current_device;
+  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(cudaSetDevice(grad.get_device()));
 
   auto num_rois = rois.size(0);
   auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
@@ -198,5 +207,6 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
          rois.contiguous().data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
+  THCudaCheck(cudaSetDevice(current_device));
   return grad_input;
 }

--- a/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
@@ -4,6 +4,7 @@
 // cyfu@cs.unc.edu
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGuard.h>
 
 #include <THC/THC.h>
 #include <THC/THCAtomics.cuh>
@@ -111,7 +112,7 @@ at::Tensor SigmoidFocalLoss_forward_cuda(
   AT_ASSERTM(targets.type().is_cuda(), "targets must be a CUDA tensor");
   AT_ASSERTM(logits.dim() == 2, "logits should be NxClass");
 
-  CUDAGuard device_guard(logits.device());
+  at::cuda::CUDAGuard device_guard(logits.device());
 
   const int num_samples = logits.size(0);
 	
@@ -159,7 +160,7 @@ at::Tensor SigmoidFocalLoss_backward_cuda(
   const int num_samples = logits.size(0);
   AT_ASSERTM(logits.size(1) == num_classes, "logits.size(1) should be num_classes");
 
-  CUDAGuard device_guard(logits.device());
+  at::cuda::CUDAGuard device_guard(logits.device());
 
   auto d_logits = at::zeros({num_samples, num_classes}, logits.options());
   auto d_logits_size = num_samples * logits.size(1);

--- a/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
@@ -111,10 +111,6 @@ at::Tensor SigmoidFocalLoss_forward_cuda(
   AT_ASSERTM(targets.type().is_cuda(), "targets must be a CUDA tensor");
   AT_ASSERTM(logits.dim() == 2, "logits should be NxClass");
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(logits.get_device()));
-
   const int num_samples = logits.size(0);
 	
   auto losses = at::empty({num_samples, logits.size(1)}, logits.options());
@@ -141,7 +137,6 @@ at::Tensor SigmoidFocalLoss_forward_cuda(
          losses.data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return losses;   
 }	
 
@@ -161,11 +156,7 @@ at::Tensor SigmoidFocalLoss_backward_cuda(
 
   const int num_samples = logits.size(0);
   AT_ASSERTM(logits.size(1) == num_classes, "logits.size(1) should be num_classes");
-
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(logits.get_device()));
-
+	
   auto d_logits = at::zeros({num_samples, num_classes}, logits.options());
   auto d_logits_size = num_samples * logits.size(1);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -192,7 +183,6 @@ at::Tensor SigmoidFocalLoss_backward_cuda(
   });
 
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return d_logits;   
 }	
 

--- a/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
@@ -111,6 +111,10 @@ at::Tensor SigmoidFocalLoss_forward_cuda(
   AT_ASSERTM(targets.type().is_cuda(), "targets must be a CUDA tensor");
   AT_ASSERTM(logits.dim() == 2, "logits should be NxClass");
 
+  int current_device;
+  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(cudaSetDevice(logits.get_device()));
+
   const int num_samples = logits.size(0);
 	
   auto losses = at::empty({num_samples, logits.size(1)}, logits.options());
@@ -137,6 +141,7 @@ at::Tensor SigmoidFocalLoss_forward_cuda(
          losses.data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
+  THCudaCheck(cudaSetDevice(current_device));
   return losses;   
 }	
 
@@ -156,7 +161,11 @@ at::Tensor SigmoidFocalLoss_backward_cuda(
 
   const int num_samples = logits.size(0);
   AT_ASSERTM(logits.size(1) == num_classes, "logits.size(1) should be num_classes");
-	
+
+  int current_device;
+  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(cudaSetDevice(logits.get_device()));
+
   auto d_logits = at::zeros({num_samples, num_classes}, logits.options());
   auto d_logits_size = num_samples * logits.size(1);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -183,6 +192,7 @@ at::Tensor SigmoidFocalLoss_backward_cuda(
   });
 
   THCudaCheck(cudaGetLastError());
+  THCudaCheck(cudaSetDevice(current_device));
   return d_logits;   
 }	
 

--- a/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
+++ b/maskrcnn_benchmark/csrc/cuda/SigmoidFocalLoss_cuda.cu
@@ -111,9 +111,7 @@ at::Tensor SigmoidFocalLoss_forward_cuda(
   AT_ASSERTM(targets.type().is_cuda(), "targets must be a CUDA tensor");
   AT_ASSERTM(logits.dim() == 2, "logits should be NxClass");
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(logits.get_device()));
+  CUDAGuard device_guard(logits.device());
 
   const int num_samples = logits.size(0);
 	
@@ -141,7 +139,6 @@ at::Tensor SigmoidFocalLoss_forward_cuda(
          losses.data<scalar_t>());
   });
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return losses;   
 }	
 
@@ -162,9 +159,7 @@ at::Tensor SigmoidFocalLoss_backward_cuda(
   const int num_samples = logits.size(0);
   AT_ASSERTM(logits.size(1) == num_classes, "logits.size(1) should be num_classes");
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(logits.get_device()));
+  CUDAGuard device_guard(logits.device());
 
   auto d_logits = at::zeros({num_samples, num_classes}, logits.options());
   auto d_logits_size = num_samples * logits.size(1);
@@ -192,7 +187,6 @@ at::Tensor SigmoidFocalLoss_backward_cuda(
   });
 
   THCudaCheck(cudaGetLastError());
-  THCudaCheck(cudaSetDevice(current_device));
   return d_logits;   
 }	
 

--- a/maskrcnn_benchmark/csrc/cuda/nms.cu
+++ b/maskrcnn_benchmark/csrc/cuda/nms.cu
@@ -70,6 +70,11 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
 at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
   using scalar_t = float;
   AT_ASSERTM(boxes.type().is_cuda(), "boxes must be a CUDA tensor");
+  
+  int current_device;
+  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(cudaSetDevice(boxes.get_device()));
+
   auto scores = boxes.select(1, 4);
   auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
   auto boxes_sorted = boxes.index_select(0, order_t);
@@ -123,6 +128,7 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
   }
 
   THCudaFree(state, mask_dev);
+  THCudaCheck(cudaSetDevice(current_device));
   // TODO improve this part
   return std::get<0>(order_t.index({
                        keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(

--- a/maskrcnn_benchmark/csrc/cuda/nms.cu
+++ b/maskrcnn_benchmark/csrc/cuda/nms.cu
@@ -70,11 +70,6 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
 at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
   using scalar_t = float;
   AT_ASSERTM(boxes.type().is_cuda(), "boxes must be a CUDA tensor");
-  
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(boxes.get_device()));
-
   auto scores = boxes.select(1, 4);
   auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
   auto boxes_sorted = boxes.index_select(0, order_t);
@@ -128,7 +123,6 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
   }
 
   THCudaFree(state, mask_dev);
-  THCudaCheck(cudaSetDevice(current_device));
   // TODO improve this part
   return std::get<0>(order_t.index({
                        keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(

--- a/maskrcnn_benchmark/csrc/cuda/nms.cu
+++ b/maskrcnn_benchmark/csrc/cuda/nms.cu
@@ -1,6 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGuard.h>
 
 #include <THC/THC.h>
 #include <THC/THCDeviceUtils.cuh>
@@ -70,7 +71,7 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
 at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
   using scalar_t = float;
   AT_ASSERTM(boxes.type().is_cuda(), "boxes must be a CUDA tensor");
-  CUDAGuard device_guard(boxes.device());
+  at::cuda::CUDAGuard device_guard(boxes.device());
   
   auto scores = boxes.select(1, 4);
   auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));

--- a/maskrcnn_benchmark/csrc/cuda/nms.cu
+++ b/maskrcnn_benchmark/csrc/cuda/nms.cu
@@ -70,9 +70,8 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
 at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
   using scalar_t = float;
   AT_ASSERTM(boxes.type().is_cuda(), "boxes must be a CUDA tensor");
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-  THCudaCheck(cudaSetDevice(boxes.get_device()));
+  CUDAGuard device_guard(boxes.device());
+  
   auto scores = boxes.select(1, 4);
   auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
   auto boxes_sorted = boxes.index_select(0, order_t);
@@ -126,7 +125,6 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
   }
 
   THCudaFree(state, mask_dev);
-  THCudaCheck(cudaSetDevice(current_device));
   // TODO improve this part
   return std::get<0>(order_t.index({
                        keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(


### PR DESCRIPTION
The current version could not normally run someone CUDA device (e.g. **cuda:1**).
The program will show such errors if we only add a extra flag `MODEL.DEVICE cuda:1`
`
2019-03-06 19:41:24,027 maskrcnn_benchmark.trainer INFO: Start training
THCudaCheck FAIL file=/home/dl/KJ/dl/core/maskrcnn-benchmark/maskrcnn_benchmark/csrc/cuda/nms.cu line=103 error=77 : an illegal memory access was encountered
`
The issue is that the current executable device (on CUDA) is device:0, while the memory data of tensors (boxes, etc.) is allocated on device:1. Therefore, we need temporary switch device 0 to 1.

After fixed the issue:
`2019-03-06 19:51:47,698 maskrcnn_benchmark.trainer INFO: Start training
2019-03-06 19:51:55,449 maskrcnn_benchmark.trainer INFO: eta: 3 days, 5:29:26  iter: 20  loss: 1.8457 (2.2689)  loss_classifier: 0.4143 (0.8737)  loss_box_reg: 0.0372 (0.0519)  loss_mask: 0.7941 (0.8378)  loss_objectness: 0.3711 (0.4117)  loss_rpn_box_reg: 0.0559 (0.0938)  time: 0.3500 (0.3875)  data: 0.0087 (0.0445)  lr: 0.001793  max mem: 3362
2019-03-06 19:52:02,983 maskrcnn_benchmark.trainer INFO: eta: 3 days, 4:24:40  iter: 40  loss: 1.3515 (1.9323)  loss_classifier: 0.3346 (0.6586)  loss_box_reg: 0.0855 (0.0689)  loss_mask: 0.7014 (0.7690)  loss_objectness: 0.2152 (0.3520)  loss_rpn_box_reg: 0.0460 (0.0838)  time: 0.3729 (0.3821)  data: 0.0100 (0.0277)  lr: 0.001927  max mem: 3466
`
The support could help some developer run the program in some limited environments.