### PR TITLE
Remove torch.cuda check in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_extensions():
     extra_compile_args = {"cxx": []}
     define_macros = []
 
-    if torch.cuda.is_available() and CUDA_HOME is not None:
+    if CUDA_HOME is not None:
         extension = CUDAExtension
         sources += source_cuda
         define_macros += [("WITH_CUDA", None)]


### PR DESCRIPTION
Let's say you want to run `docker build` on a machine without a GPU (for later use on a machine with GPU). In that case, only the `CUDA_HOME is not None` should be enough if CUDA is installed in the base image.

`torch.cuda.is_available()` on the other hand would evaluate to `false`. Or is there any important reason keep that check?

See hack at:
https://github.com/facebookresearch/maskrcnn-benchmark/issues/167#issuecomment-452796140

