### PR TITLE
Update grouped_batch_sampler.py

### DIFF
--- a/maskrcnn_benchmark/data/samplers/grouped_batch_sampler.py
+++ b/maskrcnn_benchmark/data/samplers/grouped_batch_sampler.py
@@ -40,7 +40,7 @@ class GroupedBatchSampler(BatchSampler):
     def _prepare_batches(self):
         dataset_size = len(self.group_ids)
         # get the sampled indices from the sampler
-        sampled_ids = torch.as_tensor(list(self.sampler))
+        sampled_ids = torch.as_tensor(list(self.sampler)).long()
         # potentially not all elements of the dataset were sampled
         # by the sampler (e.g., DistributedSampler).
         # construct a tensor which contains -1 if the element was

--- a/maskrcnn_benchmark/data/samplers/grouped_batch_sampler.py
+++ b/maskrcnn_benchmark/data/samplers/grouped_batch_sampler.py
@@ -40,7 +40,7 @@ class GroupedBatchSampler(BatchSampler):
     def _prepare_batches(self):
         dataset_size = len(self.group_ids)
         # get the sampled indices from the sampler
-        sampled_ids = torch.as_tensor(list(self.sampler)).long()
+        sampled_ids = torch.as_tensor(list(self.sampler), dtype=torch.int64)
         # potentially not all elements of the dataset were sampled
         # by the sampler (e.g., DistributedSampler).
         # construct a tensor which contains -1 if the element was


### PR DESCRIPTION
If the dataset is empty, then the group_ids will be an empty tensor, but with type of float32 (default tensor type), which will yield an odd error message.