### PR TITLE
APIs moved to torch.hub

### DIFF
--- a/maskrcnn_benchmark/utils/model_zoo.py
+++ b/maskrcnn_benchmark/utils/model_zoo.py
@@ -2,9 +2,10 @@
 import os
 import sys
 
-from torch.utils.model_zoo import _download_url_to_file
-from torch.utils.model_zoo import urlparse
-from torch.utils.model_zoo import HASH_REGEX
+# apis moved from torch.utils.model_zoo to torch.hub
+from torch.hub import _download_url_to_file
+from torch.hub import urlparse
+from torch.hub import HASH_REGEX
 
 from maskrcnn_benchmark.utils.comm import is_main_process
 from maskrcnn_benchmark.utils.comm import synchronize


### PR DESCRIPTION
APIs were moved from torch.utils.model_zoo to torch.hub 
As results of pytorch change - [add/move a few apis in torch.hub](https://github.com/pytorch/pytorch/pull/18758)