### PR TITLE
Add OpenCV in the INSTALL instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ conda activate maskrcnn_benchmark
 conda install ipython
 
 # maskrcnn_benchmark and coco api dependencies
-pip install ninja yacs cython matplotlib tqdm
+pip install ninja yacs cython matplotlib tqdm opencv-python
 
 # follow PyTorch installation in https://pytorch.org/get-started/locally/
 # we give the instructions for CUDA 9.0
@@ -39,7 +39,7 @@ cd cocoapi/PythonAPI
 python setup.py build_ext install
 
 # install apex
-cd ~github
+cd $INSTALL_DIR
 git clone https://github.com/NVIDIA/apex.git
 cd apex
 python setup.py install --cuda_ext --cpp_ext


### PR DESCRIPTION
Minor stuff on the INSTALL instructions:

1. After b4d546577850b156939067794f155526e262ee61, OpenCV is now required. We can either perform a check (maybe the user is using only Faster R-CNN) or just add `opencv-python` in the INSTALL instructions. This PR goes with the second option;

2. This PR also fixes the `~github` used during the `apex` install. The convention was adopted after the beginning of the `mixed-precision` PR.

If you do a fresh install and try to run the train command on the README, you get this error:

```bash
Traceback (most recent call last):
  File "tools/train_net.py", line 15, in <module>
    from maskrcnn_benchmark.data import make_data_loader
  File "/home/berriel/projects/maskrcnn-benchmark-fork/maskrcnn_benchmark/data/__init__.py", line 2, in <module>
    from .build import make_data_loader
  File "/home/berriel/projects/maskrcnn-benchmark-fork/maskrcnn_benchmark/data/build.py", line 10, in <module>
    from . import datasets as D
  File "/home/berriel/projects/maskrcnn-benchmark-fork/maskrcnn_benchmark/data/datasets/__init__.py", line 2, in <module>
    from .coco import COCODataset
  File "/home/berriel/projects/maskrcnn-benchmark-fork/maskrcnn_benchmark/data/datasets/coco.py", line 6, in <module>
    from maskrcnn_benchmark.structures.segmentation_mask import SegmentationMask
  File "/home/berriel/projects/maskrcnn-benchmark-fork/maskrcnn_benchmark/structures/segmentation_mask.py", line 1, in <module>
    import cv2
ImportError: No module named 'cv2'
```