### PR TITLE
Add a switch for POST_NMS per batch/image during training

### DIFF
--- a/maskrcnn_benchmark/config/defaults.py
+++ b/maskrcnn_benchmark/config/defaults.py
@@ -165,6 +165,9 @@ _C.MODEL.RPN.MIN_SIZE = 0
 # all FPN levels
 _C.MODEL.RPN.FPN_POST_NMS_TOP_N_TRAIN = 2000
 _C.MODEL.RPN.FPN_POST_NMS_TOP_N_TEST = 2000
+# Apply the post NMS per batch (default) or per image during training
+# (default is True to be consistent with Detectron, see Issue #672)
+_C.MODEL.RPN.FPN_POST_NMS_PER_BATCH = True
 # Custom rpn head, empty to use default conv or separable conv
 _C.MODEL.RPN.RPN_HEAD = "SingleConvRPNHead"
 


### PR DESCRIPTION
This PR complements https://github.com/facebookresearch/maskrcnn-benchmark/pull/676, adding the `MODEL.RPN.FPN_POST_NMS_PER_BATCH` switch:

- `True` (default): the code behaves AS IS, to keep it consistent with Detectron;
- `False`: POST_NMS is then applied per image, as "it should be":

https://github.com/facebookresearch/maskrcnn-benchmark/blob/08fcf12f4b8ef16e5903f859a62307950b886f89/maskrcnn_benchmark/modeling/rpn/inference.py#L157-L158

I was wondering if I should add a comment on the README; something like this (changes in bold):

> Furthermore, we set `MODEL.RPN.FPN_POST_NMS_TOP_N_TRAIN 2000` as the proposals are selected for per the batch rather than per image **in the default training**. The value is calculated by 1000 x images-per-gpu. Here we have 2 images per GPU, therefore we set the number as 1000 x 2 = 2000. If we have 8 images per GPU, the value should be set as 8000. **Note that this does not apply if `MODEL.RPN.FPN_POST_NMS_PER_BATCH` is set to `False` during training.** See [#672](https://github.com/facebookresearch/maskrcnn-benchmark/issues/672) for more details.