### PR TITLE
Update lr scheduling to pytorch 1.1.0

### DIFF
--- a/maskrcnn_benchmark/engine/trainer.py
+++ b/maskrcnn_benchmark/engine/trainer.py
@@ -59,8 +59,6 @@ def do_train(
         iteration = iteration + 1
         arguments["iteration"] = iteration
 
-        scheduler.step()
-
         images = images.to(device)
         targets = [target.to(device) for target in targets]
 
@@ -79,6 +77,7 @@ def do_train(
         with amp.scale_loss(losses, optimizer) as scaled_losses:
             scaled_losses.backward()
         optimizer.step()
+        scheduler.step()
 
         batch_time = time.time() - end
         end = time.time()


### PR DESCRIPTION
According to the docs: https://pytorch.org/docs/stable/optim.html#torch.optim.lr_scheduler.StepLR, now we need to call `scheduler.step()` after `optimizer.step()`. Breaking change PR: https://github.com/pytorch/pytorch/pull/7889

Currently, we just miss the first lr scheduler value which is not that critical.