### PR TITLE
Renames the `transforms` attribute of COCODataset

### DIFF
--- a/maskrcnn_benchmark/data/datasets/coco.py
+++ b/maskrcnn_benchmark/data/datasets/coco.py
@@ -61,7 +61,7 @@ class COCODataset(torchvision.datasets.coco.CocoDetection):
             v: k for k, v in self.json_category_id_to_contiguous_id.items()
         }
         self.id_to_img_map = {k: v for k, v in enumerate(self.ids)}
-        self.transforms = transforms
+        self._transforms = transforms
 
     def __getitem__(self, idx):
         img, anno = super(COCODataset, self).__getitem__(idx)
@@ -90,8 +90,8 @@ class COCODataset(torchvision.datasets.coco.CocoDetection):
 
         target = target.clip_to_image(remove_empty=True)
 
-        if self.transforms is not None:
-            img, target = self.transforms(img, target)
+        if self._transforms is not None:
+            img, target = self._transforms(img, target)
 
         return img, target, idx
 


### PR DESCRIPTION
Resolves the naming clash with torchvision `CocoDetection` class introduced by torchvision commit [#872](https://github.com/pytorch/vision/commit/0c36735d2ca6dfbb56a95da444b708b7c535a2c8).

For a detailed bug description, please see #738.