### PR TITLE
Update defaults.py

### DIFF
--- a/maskrcnn_benchmark/config/defaults.py
+++ b/maskrcnn_benchmark/config/defaults.py
@@ -98,8 +98,6 @@ _C.MODEL.BACKBONE.CONV_BODY = "R-50-C4"
 
 # Add StopGrad at a specified stage so the bottom layers are frozen
 _C.MODEL.BACKBONE.FREEZE_CONV_BODY_AT = 2
-# GN for backbone
-_C.MODEL.BACKBONE.USE_GN = False
 
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
remove `_C.MODEL.BACKBONE.USE_GN = False` in `config/defaults.py`, since it is not used in the code.

```
liliang@liliang-ubuntu:~/liliang_learning/maskrcnn-benchmark/maskrcnn_benchmark$ grep -r "USE_GN"
Binary file config/__pycache__/defaults.cpython-37.pyc matches
config/defaults.py:_C.MODEL.BACKBONE.USE_GN = False
config/defaults.py:_C.MODEL.FPN.USE_GN = False
config/defaults.py:_C.MODEL.ROI_BOX_HEAD.USE_GN = False
config/defaults.py:_C.MODEL.ROI_MASK_HEAD.USE_GN = False
Binary file modeling/backbone/__pycache__/backbone.cpython-37.pyc matches
modeling/backbone/backbone.py:            cfg.MODEL.FPN.USE_GN, cfg.MODEL.FPN.USE_RELU
modeling/backbone/backbone.py:            cfg.MODEL.FPN.USE_GN, cfg.MODEL.FPN.USE_RELU
Binary file modeling/roi_heads/mask_head/__pycache__/roi_mask_feature_extractors.cpython-37.pyc matches
modeling/roi_heads/mask_head/roi_mask_feature_extractors.py:        use_gn = cfg.MODEL.ROI_MASK_HEAD.USE_GN
Binary file modeling/roi_heads/box_head/__pycache__/roi_box_feature_extractors.cpython-37.pyc matches
modeling/roi_heads/box_head/roi_box_feature_extractors.py:        use_gn = cfg.MODEL.ROI_BOX_HEAD.USE_GN
modeling/roi_heads/box_head/roi_box_feature_extractors.py:        use_gn = cfg.MODEL.ROI_BOX_HEAD.USE_GN
```