### PR TITLE
fix the bug when initializing BinaryMaskList with an empty list

### DIFF
--- a/maskrcnn_benchmark/structures/segmentation_mask.py
+++ b/maskrcnn_benchmark/structures/segmentation_mask.py
@@ -52,7 +52,9 @@ class BinaryMaskList(object):
             # The raw data representation is passed as argument
             masks = masks.clone()
         elif isinstance(masks, (list, tuple)):
-            if isinstance(masks[0], torch.Tensor):
+            if len(masks) == 0:
+                masks = torch.zeros([size[1], size[0]]).clone()
+            elif isinstance(masks[0], torch.Tensor):
                 masks = torch.stack(masks, dim=2).clone()
             elif isinstance(masks[0], dict) and "counts" in masks[0]:
                 # RLE interpretation
@@ -161,7 +163,9 @@ class BinaryMaskList(object):
     def __getitem__(self, index):
         # Probably it can cause some overhead
         # but preserves consistency
-        masks = self.masks[index].clone()
+        masks = []
+        if len(torch.nonzero(self.masks)) > 0:
+            masks = self.masks[index].clone()
         return BinaryMaskList(masks, self.size)
 
     def __iter__(self):


### PR DESCRIPTION
As discussed in this [commit](https://github.com/facebookresearch/maskrcnn-benchmark/commit/b4d546577850b156939067794f155526e262ee61), [Line55](https://github.com/facebookresearch/maskrcnn-benchmark/blob/1127bdd368613f320f7b113320e62994c0baa216/maskrcnn_benchmark/structures/segmentation_mask.py#L55) for initializing a BinaryMaskList assumes the list passed in `BinaryMaskList` contains at least one element, which doesn't always hold in practice. 

My main reasons for adding this empty list handling code are as follows:
1. Support more use cases:
* When we are conducting validation, we may need to check the false positive results on both images contain target objects and images don't contain target objects. A support for accepting empty binary mask during validation is necessary.
* As discussed in #169 , some people may need training on negative examples for their custom dataset. A support for accepting empty binary mask during training is required.
2. Consistency of coding style
* In `segmentation_mask`, masks may be described as a `BinaryMaskList` or a `PolygonList`. In the implementation of `PolygonList`, [Line341](https://github.com/facebookresearch/maskrcnn-benchmark/blob/1127bdd368613f320f7b113320e62994c0baa216/maskrcnn_benchmark/structures/segmentation_mask.py#L341) could successfully deal with empty mask. Thus, a support for dealing with empty mask in `BinaryMaskList` is also necessary.

I make a simple modification for handling empty mask. The test for segmentation_mask has been passed successfully. Any comments are welcome! 