### PR TITLE
modify senario where dataset has no mask provided

### DIFF
--- a/maskrcnn_benchmark/data/datasets/coco.py
+++ b/maskrcnn_benchmark/data/datasets/coco.py
@@ -79,9 +79,8 @@ class COCODataset(torchvision.datasets.coco.CocoDetection):
         classes = torch.tensor(classes)
         target.add_field("labels", classes)
 
-        masks = [obj["segmentation"] for obj in anno if any(obj["segmentation"])]
-        if any(masks):
-            assert len(masks) == len(anno), "some bbox does not have associated mask!!"
+        if anno and "segmentation" in anno[0]:
+            masks = [obj["segmentation"] for obj in anno]
             masks = SegmentationMask(masks, img.size, mode='poly')
             target.add_field("masks", masks)
 

--- a/maskrcnn_benchmark/data/datasets/coco.py
+++ b/maskrcnn_benchmark/data/datasets/coco.py
@@ -79,9 +79,11 @@ class COCODataset(torchvision.datasets.coco.CocoDetection):
         classes = torch.tensor(classes)
         target.add_field("labels", classes)
 
-        masks = [obj["segmentation"] for obj in anno]
-        masks = SegmentationMask(masks, img.size, mode='poly')
-        target.add_field("masks", masks)
+        masks = [obj["segmentation"] for obj in anno if any(obj["segmentation"])]
+        if any(masks):
+            assert len(masks) == len(anno), "some bbox does not have associated mask!!"
+            masks = SegmentationMask(masks, img.size, mode='poly')
+            target.add_field("masks", masks)
 
         if anno and "keypoints" in anno[0]:
             keypoints = [obj["keypoints"] for obj in anno]


### PR DESCRIPTION
Hi,

As reported in [this](https://github.com/facebookresearch/maskrcnn-benchmark/issues/809) issue, when there is no `segmentation` field in the json file (which I believe will be quite common in practice, since most people would like to use this codebase in the bbox detection task), there will be a error of `index out of range` in the `boxlist` indexing operations. I feel maybe this modification would allow to get rid of this error by not adding the filed of `mask` to the `bboxlist` object.

I am not sure whether this modification is in consistent with  the designing spirit of this repo. If it is not proper to implement this modification, please let me know and I will delete this pr so that we can discuss another place where I feel maybe a little modification will make it better :)