### PR TITLE
Add dependency for Demo in Jupyter Dockerfile

### DIFF
--- a/docker/docker-jupyter/Dockerfile
+++ b/docker/docker-jupyter/Dockerfile
@@ -52,8 +52,15 @@ RUN git clone https://github.com/pytorch/vision.git \
 RUN git clone https://github.com/cocodataset/cocoapi.git \
  && cd cocoapi/PythonAPI \
  && python setup.py build_ext install
+ 
+# install apex
+RUN git clone https://github.com/NVIDIA/apex.git \
+ && cd apex \
+ && python setup.py install --cuda_ext --cpp_ext
 
 # install PyTorch Detection
+ARG FORCE_CUDA="1"
+ENV FORCE_CUDA=${FORCE_CUDA}
 RUN git clone https://github.com/facebookresearch/maskrcnn-benchmark.git \
  && cd maskrcnn-benchmark \
  && python setup.py build develop


### PR DESCRIPTION
- Fix bug where Demo notebook used to display "No module named 'apex'" due to missing apex dependency
- Port FORCE_CUDA from main Dockerfile to jupyter-docker