### PR TITLE
 remove duplication codes in heads' pooler

### DIFF
--- a/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/roi_keypoint_feature_extractors.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/roi_keypoint_feature_extractors.py
@@ -2,7 +2,7 @@ from torch import nn
 from torch.nn import functional as F
 
 from maskrcnn_benchmark.modeling import registry
-from maskrcnn_benchmark.modeling.poolers import Pooler
+from maskrcnn_benchmark.modeling.poolers import make_pooler
 
 from maskrcnn_benchmark.layers import Conv2d
 
@@ -12,15 +12,7 @@ class KeypointRCNNFeatureExtractor(nn.Module):
     def __init__(self, cfg, in_channels):
         super(KeypointRCNNFeatureExtractor, self).__init__()
 
-        resolution = cfg.MODEL.ROI_KEYPOINT_HEAD.POOLER_RESOLUTION
-        scales = cfg.MODEL.ROI_KEYPOINT_HEAD.POOLER_SCALES
-        sampling_ratio = cfg.MODEL.ROI_KEYPOINT_HEAD.POOLER_SAMPLING_RATIO
-        pooler = Pooler(
-            output_size=(resolution, resolution),
-            scales=scales,
-            sampling_ratio=sampling_ratio,
-        )
-        self.pooler = pooler
+        self.pooler = make_pooler(config, "ROI_KEYPOINT_HEAD")
 
         input_features = in_channels
         layers = cfg.MODEL.ROI_KEYPOINT_HEAD.CONV_LAYERS

--- a/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/roi_keypoint_feature_extractors.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/roi_keypoint_feature_extractors.py
@@ -12,7 +12,7 @@ class KeypointRCNNFeatureExtractor(nn.Module):
     def __init__(self, cfg, in_channels):
         super(KeypointRCNNFeatureExtractor, self).__init__()
 
-        self.pooler = make_pooler(config, "ROI_KEYPOINT_HEAD")
+        self.pooler = make_pooler(cfg, "ROI_KEYPOINT_HEAD")
 
         input_features = in_channels
         layers = cfg.MODEL.ROI_KEYPOINT_HEAD.CONV_LAYERS

--- a/maskrcnn_benchmark/modeling/roi_heads/mask_head/roi_mask_feature_extractors.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/mask_head/roi_mask_feature_extractors.py
@@ -29,7 +29,7 @@ class MaskRCNNFPNFeatureExtractor(nn.Module):
         super(MaskRCNNFPNFeatureExtractor, self).__init__()
 
         input_size = in_channels
-        self.pooler = make_pooler(config, "ROI_MASK_HEAD")
+        self.pooler = make_pooler(cfg, "ROI_MASK_HEAD")
 
         use_gn = cfg.MODEL.ROI_MASK_HEAD.USE_GN
         layers = cfg.MODEL.ROI_MASK_HEAD.CONV_LAYERS

--- a/maskrcnn_benchmark/modeling/roi_heads/mask_head/roi_mask_feature_extractors.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/mask_head/roi_mask_feature_extractors.py
@@ -4,7 +4,7 @@ from torch.nn import functional as F
 
 from ..box_head.roi_box_feature_extractors import ResNet50Conv5ROIFeatureExtractor
 from maskrcnn_benchmark.modeling import registry
-from maskrcnn_benchmark.modeling.poolers import Pooler
+from maskrcnn_benchmark.modeling.poolers import make_pooler
 from maskrcnn_benchmark.modeling.make_layers import make_conv3x3
 
 
@@ -28,16 +28,8 @@ class MaskRCNNFPNFeatureExtractor(nn.Module):
         """
         super(MaskRCNNFPNFeatureExtractor, self).__init__()
 
-        resolution = cfg.MODEL.ROI_MASK_HEAD.POOLER_RESOLUTION
-        scales = cfg.MODEL.ROI_MASK_HEAD.POOLER_SCALES
-        sampling_ratio = cfg.MODEL.ROI_MASK_HEAD.POOLER_SAMPLING_RATIO
-        pooler = Pooler(
-            output_size=(resolution, resolution),
-            scales=scales,
-            sampling_ratio=sampling_ratio,
-        )
         input_size = in_channels
-        self.pooler = pooler
+        self.pooler = make_pooler(config, "ROI_MASK_HEAD")
 
         use_gn = cfg.MODEL.ROI_MASK_HEAD.USE_GN
         layers = cfg.MODEL.ROI_MASK_HEAD.CONV_LAYERS


### PR DESCRIPTION
Instead of making pooler class directly in each head, use builder function in poolers.py to remove duplicated loading config code.