### PR TITLE
Add uncompressed rle condition in Binarymask

### DIFF
--- a/maskrcnn_benchmark/structures/segmentation_mask.py
+++ b/maskrcnn_benchmark/structures/segmentation_mask.py
@@ -60,6 +60,8 @@ class BinaryMaskList(object):
             elif isinstance(masks[0], torch.Tensor):
                 masks = torch.stack(masks, dim=2).clone()
             elif isinstance(masks[0], dict) and "counts" in masks[0]:
+                if(isinstance(masks[0]["counts"], (list, tuple))):
+                    masks = mask_utils.frPyObjects(masks, size[1], size[0])
                 # RLE interpretation
                 rle_sizes = [tuple(inst["size"]) for inst in masks]
 


### PR DESCRIPTION
Mask annotation dict can have 2 states
1. compressed RLE that was handled by code.

2. uncompressed RLE, like coco annotation
{'counts': [6, 1, 40, 4, 5, 4, 5, 4, 21], 'size': [9, 10]}
this state was not included by code condition.

