### PR TITLE
PR for #912

### DIFF
--- a/maskrcnn_benchmark/modeling/rpn/inference.py
+++ b/maskrcnn_benchmark/modeling/rpn/inference.py
@@ -169,7 +169,7 @@ class RPNPostProcessor(torch.nn.Module):
             inds_mask[inds_sorted] = 1
             inds_mask = inds_mask.split(box_sizes)
             for i in range(num_images):
-                boxlists[i] = boxlists[i][inds_mask[i]]
+                boxlists[i] = boxlists[i].masked_select(inds_mask[i])
         else:
             for i in range(num_images):
                 objectness = boxlists[i].get_field("objectness")


### PR DESCRIPTION
In the following piece of code: 
https://github.com/facebookresearch/maskrcnn-benchmark/blob/6dfb4db9d156b06a2fccbd8f8cfbd8385dd18123/maskrcnn_benchmark/modeling/rpn/inference.py#L168-L172
`inds_mask[i]` is a tensor containing only 0 and 1, which cannot serve as indices. 
`inds_mask[i]` should be used in other way.
Ref: https://github.com/facebookresearch/maskrcnn-benchmark/issues/912