### PR TITLE
Add arg for video capture device choice & update docker docs for webcam demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -42,5 +42,20 @@ docker run --rm -it \
     --config-file configs/caffe2/e2e_mask_rcnn_R_50_FPN_1x_caffe2.yaml
 ```
 
-**DISCLAIMER:** *This was tested for an Ubuntu 16.04 machine, 
+For an image built with nvidia support run:
+
+```
+docker run --rm -it \
+    --runtime=nvidia \
+    -e NVIDIA_VISIBLE_DEVICES=0 \
+    -e DISPLAY=${DISPLAY} \
+    --privileged \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    --device=/dev/video0:/dev/video0 \
+    --ipc=host maskrcnn-benchmark \
+    python demo/webcam.py --min-image-size 300 \
+    --config-file configs/caffe2/e2e_mask_rcnn_R_50_FPN_1x_caffe2.yaml
+```
+
+**DISCLAIMER:** *This was tested for on Ubuntu 16.04 and Ubuntu 18.04, 
 the volume mapping may vary depending on your platform*

--- a/demo/webcam.py
+++ b/demo/webcam.py
@@ -42,6 +42,12 @@ def main():
         help="Number of heatmaps per dimension to show",
     )
     parser.add_argument(
+        "--cam-index",
+        type=int,
+        default=0,
+        help="Index of the video device used by OpenCV to capture",
+    )
+    parser.add_argument(
         "opts",
         help="Modify model config options using the command-line",
         default=None,
@@ -64,7 +70,7 @@ def main():
         min_image_size=args.min_image_size,
     )
 
-    cam = cv2.VideoCapture(0)
+    cam = cv2.VideoCapture(args.cam_index)
     while True:
         start_time = time.time()
         ret_val, img = cam.read()


### PR DESCRIPTION
I experienced two minor issues when running the [webcam.py](https://github.com/facebookresearch/maskrcnn-benchmark/blob/master/demo/webcam.py) demo within docker:

1. I noticed that the index used by `cv2.VideoCapture()` is hard coded to 0. This didn't work for my system. So I had to change the index in the source code (to -1), then copy the new script inside the docker image and spin a new container. To avoid the hassle I expanded the arguments `parser` with a  `--cam-index` option so there is no need to touch the code when the default device mapping doesn't work; instead people can test around different values for the argument .
2. The demo [README.md](https://github.com/facebookresearch/maskrcnn-benchmark/blob/master/demo/README.md)  didn't include details on how to run the docker container with GPU support or if it works on Ubuntu 18.04, which is exactly what I tested. So I expanded the documentation with what I tested and worked for me. 