### PR TITLE
gamma, alpha are supposed to be floats, delete lines with [0] subscripts   #1013

### DIFF
--- a/maskrcnn_benchmark/layers/sigmoid_focal_loss.py
+++ b/maskrcnn_benchmark/layers/sigmoid_focal_loss.py
@@ -39,8 +39,6 @@ sigmoid_focal_loss_cuda = _SigmoidFocalLoss.apply
 
 def sigmoid_focal_loss_cpu(logits, targets, gamma, alpha):
     num_classes = logits.shape[1]
-    gamma = gamma[0]
-    alpha = alpha[0]
     dtype = targets.dtype
     device = targets.device
     class_range = torch.arange(1, num_classes+1, dtype=dtype, device=device).unsqueeze(0)


### PR DESCRIPTION
Fixes #1013

It appeared in this commit https://github.com/chengyangfu/maskrcnn-benchmark/commit/26c707e798d830bbf048380eaf78adad60873c8a#diff-10a14e932c16f4c03e825ff3f60720f0 

This is the only place of initialization of alpha and gamma.  https://github.com/facebookresearch/maskrcnn-benchmark/blob/24c8c90efdb7cc51381af5ce0205b23567c3cd21/maskrcnn_benchmark/modeling/rpn/retinanet/loss.py#L94

If I understand correctly they are supposed to be only as floats according to configs

```
cfg.MODEL.RETINANET.LOSS_GAMMA,
cfg.MODEL.RETINANET.LOSS_ALPHA
```

- [unittests OK] 

I tried to run this for `configs/retinanet/retinanet_R-50-FPN_P5_1x.yaml`
- [train_net.py, test_net.py with GPU]
- [test_net.py with CPU]


