### PR TITLE
remove redundant reshape of box_regression

### DIFF
--- a/maskrcnn_benchmark/modeling/rpn/retinanet/inference.py
+++ b/maskrcnn_benchmark/modeling/rpn/retinanet/inference.py
@@ -74,7 +74,6 @@ class RetinaNetPostProcessor(RPNPostProcessor):
         box_cls = box_cls.sigmoid()
 
         box_regression = permute_and_flatten(box_regression, N, A, 4, H, W)
-        box_regression = box_regression.reshape(N, -1, 4)
 
         num_anchors = A * H * W
 


### PR DESCRIPTION
Remove redundant reshape in line `77` 
https://github.com/facebookresearch/maskrcnn-benchmark/blob/24c8c90efdb7cc51381af5ce0205b23567c3cd21/maskrcnn_benchmark/modeling/rpn/retinanet/inference.py#L76-L77
Because `permute_and_flatten` makes this reshape already
https://github.com/facebookresearch/maskrcnn-benchmark/blob/24c8c90efdb7cc51381af5ce0205b23567c3cd21/maskrcnn_benchmark/modeling/rpn/utils.py#L10-L14