### PR TITLE
Fix tensor type checking for pytorch 1.2

### DIFF
--- a/maskrcnn_benchmark/structures/segmentation_mask.py
+++ b/maskrcnn_benchmark/structures/segmentation_mask.py
@@ -454,7 +454,8 @@ class PolygonList(object):
         else:
             # advanced indexing on a single dimension
             selected_polygons = []
-            if isinstance(item, torch.Tensor) and item.dtype == torch.uint8:
+            if isinstance(item, torch.Tensor) and \
+                    (item.dtype == torch.uint8 or item.dtype == torch.bool):
                 item = item.nonzero()
                 item = item.squeeze(1) if item.numel() > 0 else item
                 item = item.tolist()


### PR DESCRIPTION
Fix https://github.com/facebookresearch/maskrcnn-benchmark/issues/725.
In pytorch 1.2, comparison operations return torch.bool instead of torch.uint8, which causes the error.
Ideally we should change all mask to torch.bool. Indexing with torch.uint8 also leads to infinite warning.