### PR TITLE
install local pip with conda

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,11 +17,11 @@
 # for that, check that `which conda`, `which pip` and `which python` points to the
 # right path. From a clean conda env, this is what you need to do
 
-conda create --name maskrcnn_benchmark
+conda create --name maskrcnn_benchmark -y
 conda activate maskrcnn_benchmark
 
 # this installs the right pip and dependencies for the fresh python
-conda install ipython
+conda install ipython pip
 
 # maskrcnn_benchmark and coco api dependencies
 pip install ninja yacs cython matplotlib tqdm opencv-python


### PR DESCRIPTION
creating the conda env does not come with a local version of pip, therefore in line 27 it would be quite non-deterministic where the installed lib would end up, possibly causing collisions with different versions of this or other repos