### PR TITLE
Fix cityscapes to coco conversion script

### DIFF
--- a/tools/cityscapes/convert_cityscapes_to_coco.py
+++ b/tools/cityscapes/convert_cityscapes_to_coco.py
@@ -29,7 +29,7 @@ import os
 import scipy.misc
 import sys
 
-import cityscapesscripts.evaluation.instances2dict_with_polygons as cs
+import instances2dict_with_polygons as cs
 
 
 def parse_args():

--- a/tools/cityscapes/instances2dict_with_polygons.py
+++ b/tools/cityscapes/instances2dict_with_polygons.py
@@ -6,9 +6,6 @@
 from __future__ import print_function, absolute_import, division
 import os, sys
 
-sys.path.append( os.path.normpath( os.path.join( os.path.dirname( __file__ ) , '..' , 'helpers' ) ) )
-from csHelpers import *
-
 # Cityscapes imports
 from cityscapesscripts.evaluation.instance import *
 from cityscapesscripts.helpers.csHelpers import *


### PR DESCRIPTION
Fixed cityscapes to coco conversion script:

* Allow `instances2dict_with_polygons` to be imported from the same folder (as it's not present in Cityscapes [scripts](https://github.com/mcordts/cityscapesScripts/tree/master/cityscapesscripts/evaluation)).
* Remove unnecessary redundant `csHelpers` import.