### PR TITLE
Extend COCO evaluation for AbstractDataset 

### DIFF
--- a/maskrcnn_benchmark/data/datasets/evaluation/coco/__init__.py
+++ b/maskrcnn_benchmark/data/datasets/evaluation/coco/__init__.py
@@ -1,4 +1,6 @@
-from .coco_eval import do_coco_evaluation
+from .coco_eval import do_coco_evaluation as do_orig_coco_evaluation
+from .coco_eval_wrapper import do_coco_evaluation as do_wrapped_coco_evaluation
+from maskrcnn_benchmark.data.datasets import AbstractDataset, COCODataset
 
 
 def coco_evaluation(
@@ -10,12 +12,31 @@ def coco_evaluation(
     expected_results,
     expected_results_sigma_tol,
 ):
-    return do_coco_evaluation(
-        dataset=dataset,
-        predictions=predictions,
-        box_only=box_only,
-        output_folder=output_folder,
-        iou_types=iou_types,
-        expected_results=expected_results,
-        expected_results_sigma_tol=expected_results_sigma_tol,
-    )
+    if isinstance(dataset, COCODataset):
+        return do_orig_coco_evaluation(
+            dataset=dataset,
+            predictions=predictions,
+            box_only=box_only,
+            output_folder=output_folder,
+            iou_types=iou_types,
+            expected_results=expected_results,
+            expected_results_sigma_tol=expected_results_sigma_tol,
+        )
+    elif isinstance(dataset, AbstractDataset):
+        return do_wrapped_coco_evaluation(
+            dataset=dataset,
+            predictions=predictions,
+            box_only=box_only,
+            output_folder=output_folder,
+            iou_types=iou_types,
+            expected_results=expected_results,
+            expected_results_sigma_tol=expected_results_sigma_tol,
+        )
+    else:
+        raise NotImplementedError(
+            (
+                "Ground truth dataset is not a COCODataset, "
+                "nor it is derived from AbstractDataset: type(dataset)="
+                "%s" % type(dataset)
+            )
+        )

--- a/maskrcnn_benchmark/data/datasets/evaluation/coco/abs_to_coco.py
+++ b/maskrcnn_benchmark/data/datasets/evaluation/coco/abs_to_coco.py
@@ -1,0 +1,198 @@
+# COCO style evaluation for custom datasets derived from AbstractDataset
+# Warning! area is computed using binary maps, therefore results may differ
+# because of the precomputed COCO areas
+# by botcs@github
+
+import numpy as np
+import torch
+import pycocotools.mask as mask_util
+
+from maskrcnn_benchmark.data.datasets.abstract import AbstractDataset
+from maskrcnn_benchmark.structures.bounding_box import BoxList
+
+import logging
+from datetime import datetime
+from tqdm import tqdm
+
+
+def convert_abstract_to_coco(dataset, num_workers=None, chunksize=100):
+    """
+    Convert any dataset derived from AbstractDataset to COCO style
+    for evaluating with the pycocotools lib
+
+    Conversion imitates required fields of COCO instance segmentation
+    ground truth files like: ".../annotations/instances_train2014.json"
+
+    After th conversion is done a dict is returned that follows the same
+    format as COCO json files.
+
+    By default .coco_eval_wrapper.py saves it to the hard-drive in json format
+    and loads it with the maskrcnn_benchmark's default COCODataset
+
+    Args:
+        dataset: any dataset derived from AbstractDataset
+        num_workers (optional): number of worker threads to parallelize the
+            conversion (default is to use all cores for conversion)
+        chunk_size (optional): how many entries one thread processes before
+            requesting new task. The larger the less overhead there is.
+    """
+
+    logger = logging.getLogger("maskrcnn_benchmark.inference")
+    assert isinstance(dataset, AbstractDataset)
+    # Official COCO annotations have these fields
+    # 'info', 'licenses', 'images', 'type', 'annotations', 'categories'
+    coco_dict = {}
+    coco_dict["info"] = {
+        "description": (
+            "This is an automatically generated COCO annotation"
+            " file using maskrcnn_benchmark"
+        ),
+        "date_created": "%s" % datetime.now(),
+    }
+    coco_dict["type"] = "instances"
+
+    images = []
+    annotations = []
+
+    if num_workers is None:
+        num_workers = torch.multiprocessing.cpu_count()
+    else:
+        num_workers = min(num_workers, torch.multiprocessing.cpu_count())
+
+    dataset_name = dataset.__class__.__name__
+    num_images = len(dataset)
+    logger.info(
+        (
+            "Parsing each entry in "
+            "%s, total=%d. "
+            "Using N=%d workers and chunksize=%d"
+        )
+        % (dataset_name, num_images, num_workers, chunksize)
+    )
+
+    with torch.multiprocessing.Pool(num_workers) as pool:
+        with tqdm(total=num_images) as progress_bar:
+            args = [(dataset, idx) for idx in range(num_images)]
+            iterator = pool.imap(process_single_image, args, chunksize=100)
+            for img_annots_pair in iterator:
+                image, per_img_annotations = img_annots_pair
+
+                images.append(image)
+                annotations.extend(per_img_annotations)
+                progress_bar.update()
+
+    for ann_id, ann in enumerate(annotations, 1):
+        ann["id"] = ann_id
+
+    logger.info("Parsing categories:")
+    # CATEGORY DATA
+    categories = [
+        {"id": category_id, "name": name}
+        for category_id, name in dataset.id_to_name.items()
+        if name != "__background__"
+    ]
+    # Logging categories
+    for cat in categories:
+        logger.info(str(cat))
+
+    coco_dict["images"] = images
+    coco_dict["annotations"] = annotations
+    coco_dict["categories"] = categories
+    return coco_dict
+
+
+def process_single_image(args):
+    dataset, idx = args
+    # IMAGE DATA
+    img_id = idx + 1
+    image = {}
+    # Official COCO "images" entries have these fields
+    # 'license', 'url', 'file_name', 'height', 'width', 'date_captured', 'id'
+
+    img, target, ret_idx = dataset[idx]
+    img_info = dataset.get_img_info(idx)
+    assert isinstance(img_info, dict)
+    image.update(img_info)
+    image["width"], image["height"] = target.size
+
+    if "id" not in image.keys():
+        # Start indexing from 1 if "id" field is not present
+        image["id"] = img_id
+    else:
+        img_id = image["id"]
+
+    # ANNOTATION DATA
+    per_img_annotations = []
+    # Official COCO "annotations" entries have these fields
+    # 'segmentation', 'area', 'iscrowd', 'image_id', 'bbox', 'category_id', 'id'
+
+    #
+
+    assert ret_idx == idx, (ret_idx, idx)
+    assert isinstance(target, BoxList)
+
+    bboxes = target.convert("xywh").bbox.tolist()
+    segm_available = "masks" in target.fields()
+    if segm_available:
+        masks = target.get_field("masks").get_mask_tensor()  # [N, H, W]
+        if masks.dim() == 2:
+            masks = masks.unsqueeze(0)
+        rles = masks_to_rles(masks)
+        """
+        !!!WARNING!!!
+        At this point the area value differs from the precomputed
+        original COCO area values, because we compute the area
+        by counting the nonzero entries of the binary mask
+        while COCO areas are computed directly from the polygons
+
+        Example:
+        Reference image data
+        {'license': 2,
+         'url': 'http://farm9.staticflickr.com/8035/8024364858_9c41dc1666_z.jpg',
+         'file_name': 'COCO_val2014_000000000139.jpg',
+         'height': 426,
+         'width': 640,
+         'date_captured': '2013-11-21 01:34:01',
+         'id': 139}
+
+        Original COCO area values
+        [  531.8071, 13244.6572,  5833.1182,  2245.3435,  1833.7841,  1289.3734,
+           210.1482,  2913.1104,   435.1450,   217.7192,  2089.9749,   338.6089,
+           322.5936,   225.6642,  2171.6189,   178.1851,    90.9873,   189.5601,
+           120.2320,  2362.4897]
+
+        Area values using the binary masks
+        [  531, 13247,  5846,  2251,  1850,  1292,   212,  2922,   439,   224,
+           2060,   342,   324,   226,  2171,   178,    90,   187,   120,  2372]
+        """
+        areas = (masks != 0).sum([1, 2]).tolist()
+    else:
+        areas = target.area().tolist()
+
+    cat_ids = target.get_field("labels").long().tolist()
+    assert len(bboxes) == len(areas) == len(cat_ids)
+    num_instances = len(target)
+    for ann_idx in range(num_instances):
+        annotation = {}
+        if segm_available:
+            annotation["segmentation"] = rles[ann_idx]
+        annotation["area"] = areas[ann_idx]
+        annotation["iscrowd"] = 0
+        annotation["image_id"] = img_id
+        annotation["bbox"] = bboxes[ann_idx]
+        annotation["category_id"] = cat_ids[ann_idx]
+        per_img_annotations.append(annotation)
+
+    return image, per_img_annotations
+
+
+def masks_to_rles(masks_tensor):
+    # TODO: parallelize
+    rles = []
+    for instance_mask in masks_tensor:
+        np_mask = np.array(instance_mask[:, :, None], order="F")
+        rle = mask_util.encode(np_mask)[0]
+        rle["counts"] = rle["counts"].decode("utf-8")
+        rles.append(rle)
+
+    return rles

--- a/maskrcnn_benchmark/data/datasets/evaluation/coco/coco_eval_wrapper.py
+++ b/maskrcnn_benchmark/data/datasets/evaluation/coco/coco_eval_wrapper.py
@@ -1,0 +1,49 @@
+# COCO style evaluation for custom datasets derived from AbstractDataset
+# by botcs@github
+
+import logging
+import os
+import json
+
+from maskrcnn_benchmark.data.datasets.coco import COCODataset
+from .coco_eval import do_coco_evaluation as orig_evaluation
+from .abs_to_coco import convert_abstract_to_coco
+
+
+def do_coco_evaluation(
+    dataset,
+    predictions,
+    box_only,
+    output_folder,
+    iou_types,
+    expected_results,
+    expected_results_sigma_tol,
+):
+
+    logger = logging.getLogger("maskrcnn_benchmark.inference")
+    logger.info("Converting annotations to COCO format...")
+    coco_annotation_dict = convert_abstract_to_coco(dataset)
+
+    dataset_name = dataset.__class__.__name__
+    coco_annotation_path = os.path.join(output_folder, dataset_name + ".json")
+    logger.info("Saving annotations to %s" % coco_annotation_path)
+    with open(coco_annotation_path, "w") as f:
+        json.dump(coco_annotation_dict, f, indent=2)
+
+    logger.info("Loading annotations as COCODataset")
+    coco_dataset = COCODataset(
+        ann_file=coco_annotation_path,
+        root="",
+        remove_images_without_annotations=False,
+        transforms=None,  # transformations should be already saved to the json
+    )
+
+    return orig_evaluation(
+        dataset=coco_dataset,
+        predictions=predictions,
+        box_only=box_only,
+        output_folder=output_folder,
+        iou_types=iou_types,
+        expected_results=expected_results,
+        expected_results_sigma_tol=expected_results,
+    )


### PR DESCRIPTION
# Extending COCO evaluation
Using the standard `maskrcnn_benchmark/data/datasets/evaluation/coco/` tools, this PR introduces a wrapper that works with any derived class of the `AbstractDataset` and translates them into COCO annotation format ([details here](http://cocodataset.org/#format-data)). 

To unit-test this functionality the following measurement was carried out:
1. Derive a custom dataset `AbstractCOCO` from `AbstractDataset` 
2. wrap the original `COCODataset` inside `AbstractCOCO`. 
3. Evaluate `e2e_mask_rcnn_R_50_FPN_1x` and `e2e_mask_rcnn_R_50_FPN_1x`  with each dataset
5. Use the extended COCO evaluation tool and compare the results with the original tool.
4. **Results are non identical** because AbstractCOCO computes area by counting the nonzero entries of the binary masks, while in COCO annotations the area values were precomputed (possibly from the polygons). For detailed comparison please see the summary below:

<details><summary>Detailed results</summary>
<p>

## e2e_mask_rcnn_R_50_FPN_1x

### COCODataset

```
Evaluate annotation type *bbox*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.378
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.592
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.411
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.215
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.411
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.498
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.313
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.491
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.515
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.328
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.551
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.652

Evaluate annotation type *segm*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.342
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.560
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.363
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.156
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.368
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.506
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.293
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.448
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.468
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.272
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.505
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.623
```

### AbstractCOCO

```
Evaluate annotation type *bbox*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.371
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.583
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.404
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.137
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.315
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.470
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.311
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.488
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.511
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.229
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.456
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.623

Evaluate annotation type *segm*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.342
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.556
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.365
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.094
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.265
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.467
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.295
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.451
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.471
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.186
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.408
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.592
```

## e2e_mask_rcnn_R_101_FPN_1x

### COCODataset

```
Evaluate annotation type *bbox*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.401
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.617
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.440
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.230
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.434
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.526
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.325
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.510
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.534
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.349
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.570
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.676

Evaluate annotation type *segm*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.361
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.581
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.383
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.164
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.389
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.534
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.303
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.464
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.484
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.279
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.522
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.644
```

### AbstractCOCO

```
Evaluate annotation type *bbox*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.394
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.607
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.432
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.160
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.336
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.499
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.324
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.507
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.531
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.252
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.478
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.646

Evaluate annotation type *segm*
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.361
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.576
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.384
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.112
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.282
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.492
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.304
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.466
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.486
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.206
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.422
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.611
```

</p>
</details>

<details><summary>Differences in precomputed vs binary mask areas</summary>
<p>

        Original COCO area values
        [  531.8071, 13244.6572,  5833.1182,  2245.3435,  1833.7841,  1289.3734,
           210.1482,  2913.1104,   435.1450,   217.7192,  2089.9749,   338.6089,
           322.5936,   225.6642,  2171.6189,   178.1851,    90.9873,   189.5601,
           120.2320,  2362.4897]

        Area values using the binary masks
        [  531, 13247,  5846,  2251,  1850,  1292,   212,  2922,   439,   224,
           2060,   342,   324,   226,  2171,   178,    90,   187,   120,  2372]

</p>
</details>

Thanks,
Csabi