### PR TITLE
fix #720: edit INSTALL instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,7 @@ python setup.py build_ext install
 cd $INSTALL_DIR
 git clone https://github.com/NVIDIA/apex.git
 cd apex
-python setup.py install --cuda_ext --cpp_ext
+python setup.py install --cuda_ext --cpp_ext # or: `python setup.py install` for CPU only
 
 # install PyTorch Detection
 cd $INSTALL_DIR


### PR DESCRIPTION
along with https://github.com/NVIDIA/apex/pull/516, makes it possible to run demo on CPU only (eg on mac)