### PR TITLE
replacing dtype torch.uint8 with torch.bool for indexing in pytorch 1.2.0

### DIFF
--- a/demo/predictor.py
+++ b/demo/predictor.py
@@ -326,7 +326,7 @@ class COCODemo(object):
         colors = self.compute_colors_for_labels(labels).tolist()
 
         for mask, color in zip(masks, colors):
-            thresh = mask[0, :, :, None]
+            thresh = mask[0, :, :, None].astype(np.uint8)
             contours, hierarchy = cv2_util.findContours(
                 thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
             )

--- a/maskrcnn_benchmark/modeling/balanced_positive_negative_sampler.py
+++ b/maskrcnn_benchmark/modeling/balanced_positive_negative_sampler.py
@@ -54,10 +54,10 @@ class BalancedPositiveNegativeSampler(object):
 
             # create binary mask from indices
             pos_idx_per_image_mask = torch.zeros_like(
-                matched_idxs_per_image, dtype=torch.uint8
+                matched_idxs_per_image, dtype=torch.bool
             )
             neg_idx_per_image_mask = torch.zeros_like(
-                matched_idxs_per_image, dtype=torch.uint8
+                matched_idxs_per_image, dtype=torch.bool
             )
             pos_idx_per_image_mask[pos_idx_per_image] = 1
             neg_idx_per_image_mask[neg_idx_per_image] = 1

--- a/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/loss.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/loss.py
@@ -154,7 +154,7 @@ class KeypointRCNNLossComputation(object):
             valid.append(valid_per_image.view(-1))
 
         keypoint_targets = cat(heatmaps, dim=0)
-        valid = cat(valid, dim=0).to(dtype=torch.uint8)
+        valid = cat(valid, dim=0).to(dtype=torch.bool)
         valid = torch.nonzero(valid).squeeze(1)
 
         # torch.mean (in binary_cross_entropy_with_logits) does'nt

--- a/maskrcnn_benchmark/modeling/roi_heads/mask_head/inference.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/mask_head/inference.py
@@ -145,9 +145,9 @@ def paste_mask_in_image(mask, box, im_h, im_w, thresh=0.5, padding=1):
     else:
         # for visualization and debugging, we also
         # allow it to return an unmodified mask
-        mask = (mask * 255).to(torch.uint8)
+        mask = (mask * 255).to(torch.bool)
 
-    im_mask = torch.zeros((im_h, im_w), dtype=torch.uint8)
+    im_mask = torch.zeros((im_h, im_w), dtype=torch.bool)
     x_0 = max(box[0], 0)
     x_1 = min(box[2] + 1, im_w)
     y_0 = max(box[1], 0)

--- a/maskrcnn_benchmark/modeling/rpn/anchor_generator.py
+++ b/maskrcnn_benchmark/modeling/rpn/anchor_generator.py
@@ -106,7 +106,7 @@ class AnchorGenerator(nn.Module):
             )
         else:
             device = anchors.device
-            inds_inside = torch.ones(anchors.shape[0], dtype=torch.uint8, device=device)
+            inds_inside = torch.ones(anchors.shape[0], dtype=torch.bool, device=device)
         boxlist.add_field("visibility", inds_inside)
 
     def forward(self, image_list, feature_maps):

--- a/maskrcnn_benchmark/modeling/rpn/inference.py
+++ b/maskrcnn_benchmark/modeling/rpn/inference.py
@@ -165,7 +165,7 @@ class RPNPostProcessor(torch.nn.Module):
             box_sizes = [len(boxlist) for boxlist in boxlists]
             post_nms_top_n = min(self.fpn_post_nms_top_n, len(objectness))
             _, inds_sorted = torch.topk(objectness, post_nms_top_n, dim=0, sorted=True)
-            inds_mask = torch.zeros_like(objectness, dtype=torch.uint8)
+            inds_mask = torch.zeros_like(objectness, dtype=torch.bool)
             inds_mask[inds_sorted] = 1
             inds_mask = inds_mask.split(box_sizes)
             for i in range(num_images):

--- a/maskrcnn_benchmark/structures/segmentation_mask.py
+++ b/maskrcnn_benchmark/structures/segmentation_mask.py
@@ -441,7 +441,7 @@ class PolygonList(object):
             )
         else:
             size = self.size
-            masks = torch.empty([0, size[1], size[0]], dtype=torch.uint8)
+            masks = torch.empty([0, size[1], size[0]], dtype=torch.bool)
 
         return BinaryMaskList(masks, size=self.size)
 
@@ -456,7 +456,7 @@ class PolygonList(object):
         else:
             # advanced indexing on a single dimension
             selected_polygons = []
-            if isinstance(item, torch.Tensor) and item.dtype == torch.uint8:
+            if isinstance(item, torch.Tensor) and item.dtype == torch.bool:
                 item = item.nonzero()
                 item = item.squeeze(1) if item.numel() > 0 else item
                 item = item.tolist()


### PR DESCRIPTION
Indexing with dtype torch.uint8 is deprecated in pytorch 1.2.0. Current version generates lots of warnings like "/opt/conda/conda-bld/pytorch_1565272271120/work/aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead." 
In this PR, dtype torch.uint8 is replaced with torch.bool for indexing in compliance with pytorch 1.2.0.