### PR TITLE
Modify filter_results for nms

### DIFF
--- a/maskrcnn_benchmark/modeling/roi_heads/box_head/inference.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/box_head/inference.py
@@ -140,11 +140,7 @@ class PostProcessor(nn.Module):
         # Limit to max_per_image detections **over all classes**
         if number_of_detections > self.detections_per_img > 0:
             cls_scores = result.get_field("scores")
-            image_thresh, _ = torch.kthvalue(
-                cls_scores.cpu(), number_of_detections - self.detections_per_img + 1
-            )
-            keep = cls_scores >= image_thresh.item()
-            keep = torch.nonzero(keep).squeeze(1)
+            _, keep = torch.topk(cls_scores.cpu(), k=self.detections_per_img)
             result = result[keep]
         return result
 


### PR DESCRIPTION
Original code:
 image_thresh, _ = torch.kthvalue(cls_scores.cpu(), number_of_detections - self.detections_per_img )
 keep = cls_scores >= image_thresh.item()
 
if there are many values same to images_thresh in cls_scores, then variable 'keep' can have more than self.detections_per_img. For example:
cls_scores =[1,1,1,1,1,1,1,1],     self.detections_per_img = 2
image_thresh = torch.kthvalue(cls_scores.cpu, 2 )  --> 1
keep = [True, True, True,.......], which will be more than self.detections_per_imgs.